### PR TITLE
Generate nmdc-schema-flattened LinkML schema

### DIFF
--- a/justfile
+++ b/justfile
@@ -159,6 +159,11 @@ export-nmdc-parquet: export-nmdc-duckdb
     uv run python scripts/python/export_duckdb_to_parquet.py "{{nmdc_duckdb_file}}" --output-dir "{{nmdc_parquet_dir}}"
 
 # Full pipeline: flatten in Mongo -> DuckDB -> Parquet -> biosample CSV.
+# Generate the flattened LinkML schema (one class per Database slot).
+# Output: ./local/nmdc_schema_flattened.yaml
+generate-flat-schema:
+    @uv run python scripts/python/generate_flattened_schema.py
+
 flatten-and-export-nmdc: flatten-nmdc export-nmdc-parquet export-flattened-biosample-csv
     @echo ""
     @echo "=== NMDC flatten and export complete ==="

--- a/scripts/python/generate_flattened_schema.py
+++ b/scripts/python/generate_flattened_schema.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Emit the flattened LinkML schema for nmdc-schema's Database class.
+
+Walks the installed ``nmdc-schema`` package, generates a flat
+``ClassDefinition`` for each multivalued ``Database`` slot via
+:func:`nmdc_lakehouse.transforms.schema_generator.flatten_database_schema`,
+and writes the resulting schema to disk as YAML.
+
+Usage:
+    uv run python scripts/python/generate_flattened_schema.py [OUTPUT_PATH]
+
+Default OUTPUT_PATH: ./local/nmdc_schema_flattened.yaml
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+
+from nmdc_lakehouse.transforms.schema_generator import flatten_database_schema
+
+
+def main() -> None:
+    """Generate the flattened schema and write it to disk."""
+    out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("./local/nmdc_schema_flattened.yaml")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    spec = find_spec("nmdc_schema")
+    if spec is None or not spec.submodule_search_locations:
+        print("nmdc_schema package is not installed", file=sys.stderr)
+        sys.exit(1)
+    schema_path = f"{spec.submodule_search_locations[0]}/nmdc_materialized_patterns.yaml"
+    sv = SchemaView(schema_path)
+
+    flat_schema = flatten_database_schema(sv)
+    yaml_str = yaml_dumper.dumps(flat_schema)
+    out_path.write_text(yaml_str)
+
+    print(f"Wrote {out_path}")
+    print(f"  classes: {len(flat_schema.classes)}")
+    for name, cls in sorted(flat_schema.classes.items()):
+        print(f"    {name}: {len(cls.attributes)} attrs")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nmdc_lakehouse/transforms/schema_generator.py
+++ b/src/nmdc_lakehouse/transforms/schema_generator.py
@@ -1,10 +1,10 @@
 """Generate a LinkML schema describing the flat shape produced by the flattener.
 
 Given a source LinkML schema (e.g. nmdc-schema) and a root class, emit a new
-:class:`ClassDefinition` whose attributes mirror what
-:func:`nmdc_lakehouse.transforms.flatteners.flatten_record` produces. The
-decision tree matches the flattener's one-to-one, so the generated schema
-and the runtime output can't drift.
+:class:`ClassDefinition` whose attributes mirror the flat output produced by
+:meth:`nmdc_lakehouse.transforms.flatteners.SchemaDrivenFlattener.apply`. The
+decision tree matches the runtime flattener one-to-one, so the generated
+schema and the runtime output can't drift.
 
 For polymorphic base classes (where records may declare a concrete subclass
 via ``type``), the generated flat class contains the **union of all subclass
@@ -26,10 +26,11 @@ from linkml_runtime.linkml_model import (
 
 
 def _is_inlined(slot: SlotDefinition, schema_view: SchemaView) -> bool:
-    """LinkML's identifier-based default for whether a class-range slot is inlined.
+    """Apply LinkML's identifier-based default for class-range slot inlining.
 
-    Mirrors the helper in flatteners.py so the generator and the runtime
-    flattener agree on which slots get expanded vs. treated as references.
+    Keeps schema generation aligned with the runtime flattener's
+    expanded-vs-reference decision. Both modules implement the same rule
+    independently rather than sharing a helper.
     """
     if slot.inlined is not None:
         return slot.inlined

--- a/src/nmdc_lakehouse/transforms/schema_generator.py
+++ b/src/nmdc_lakehouse/transforms/schema_generator.py
@@ -1,0 +1,329 @@
+"""Generate a LinkML schema describing the flat shape produced by the flattener.
+
+Given a source LinkML schema (e.g. nmdc-schema) and a root class, emit a new
+:class:`ClassDefinition` whose attributes mirror what
+:func:`nmdc_lakehouse.transforms.flatteners.flatten_record` produces. The
+decision tree matches the flattener's one-to-one, so the generated schema
+and the runtime output can't drift.
+
+For polymorphic base classes (where records may declare a concrete subclass
+via ``type``), the generated flat class contains the **union of all subclass
+slots**. Subclass-specific slots are emitted as non-required so parquet can
+hold them sparsely.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model import (
+    ClassDefinition,
+    Prefix,
+    SchemaDefinition,
+    SlotDefinition,
+)
+
+
+def _is_inlined(slot: SlotDefinition, schema_view: SchemaView) -> bool:
+    """LinkML's identifier-based default for whether a class-range slot is inlined.
+
+    Mirrors the helper in flatteners.py so the generator and the runtime
+    flattener agree on which slots get expanded vs. treated as references.
+    """
+    if slot.inlined is not None:
+        return slot.inlined
+    if not slot.range:
+        return False
+    if schema_view.get_class(slot.range) is None:
+        return False
+    return schema_view.get_identifier_slot(slot.range) is None
+
+
+LIST_JOIN_NOTE = "Multivalued slot flattened to a pipe-separated string (values joined with '|')."
+REF_NOTE = "Reference by identifier; original range was class '{range}'."
+NESTED_NOTE = "Flattened from nested slot '{parent}.{inner}'."
+DISPATCH_NOTE = "Polymorphic subclass-specific slot (from '{subclass}')."
+
+
+def flatten_class_def(schema_view: SchemaView, root_class: str, target_name: str | None = None) -> ClassDefinition:
+    """Return a new ClassDefinition describing the flat form of ``root_class``.
+
+    Walks the same decision tree as ``flatten_record``:
+
+    - scalar → flat slot with same range
+    - multivalued scalar → flat slot with string range (pipe-joined)
+    - class range, not inlined → flat slot with string range (ID reference)
+    - single-valued inlined class → one flat slot per subclass scalar slot,
+      named ``<parent>_<inner>`` (one or two levels deep)
+    - multivalued inlined class → **skipped** (helper-table follow-up)
+
+    Union polymorphism: slots on concrete subclasses of ``root_class`` are
+    unioned in, annotated with ``DISPATCH_NOTE`` so downstream consumers can
+    tell base-class from subclass-specific columns.
+
+    Args:
+        schema_view: Loaded SchemaView over the source schema.
+        root_class: Name of the class to flatten.
+        target_name: Name for the generated class. Defaults to ``<root_class>Flat``.
+
+    Returns:
+        A new ``ClassDefinition``. Attributes are flat ``SlotDefinition``s.
+    """
+    target_name = target_name or f"{root_class}Flat"
+    cls = ClassDefinition(name=target_name)
+    cls.description = (
+        f"Flattened tabular form of '{root_class}' produced by "
+        f"`SchemaDrivenFlattener`. Attributes are the union of base-class "
+        f"slots and slots from concrete subclasses of '{root_class}' that "
+        f"may appear via the 'type' field."
+    )
+
+    attrs: dict[str, SlotDefinition] = {}
+
+    # Base class slots — faithful to induced_slots(root_class)
+    for slot in schema_view.class_induced_slots(root_class):
+        for flat in _flatten_slot(slot, schema_view):
+            attrs.setdefault(flat.name, flat)
+
+    # Union in slots from concrete subclasses (polymorphic dispatch)
+    for descendant in _proper_descendants(schema_view, root_class):
+        for slot in schema_view.class_induced_slots(descendant):
+            for flat in _flatten_slot(slot, schema_view, dispatch_subclass=descendant):
+                # Keep the first-seen slot (base class takes precedence); add
+                # a dispatch annotation if only a subclass contributed it.
+                attrs.setdefault(flat.name, flat)
+
+    # Deterministic ordering for reproducible output
+    for name in sorted(attrs):
+        cls.attributes[name] = attrs[name]
+
+    return cls
+
+
+def flatten_database_schema(
+    schema_view: SchemaView,
+    database_class: str = "Database",
+    schema_id: str = "https://w3id.org/nmdc/nmdc-schema-flattened",
+    schema_name: str = "nmdc_schema_flattened",
+) -> SchemaDefinition:
+    """Emit a full SchemaDefinition with one flat class per Database slot.
+
+    Walks each multivalued slot on ``database_class`` (the 17 NMDC collections),
+    resolves its range, and calls :func:`flatten_class_def` to produce a flat
+    class for each.
+    """
+    out = SchemaDefinition(
+        id=schema_id,
+        name=schema_name,
+        description=(
+            "Flattened LinkML schema describing the tabular output of "
+            "`SchemaDrivenFlattener` applied to each schema-specified "
+            "collection. Generated — do not edit by hand."
+        ),
+        prefixes={
+            "linkml": Prefix(
+                prefix_prefix="linkml",
+                prefix_reference="https://w3id.org/linkml/",
+            ),
+        },
+        imports=["linkml:types"],
+        default_range="string",
+    )
+
+    db_slots = schema_view.class_induced_slots(database_class)
+    for slot in db_slots:
+        if not slot.multivalued or not slot.range:
+            continue
+        range_class = schema_view.get_class(slot.range)
+        if range_class is None:
+            continue
+        flat = flatten_class_def(schema_view, slot.range)
+        out.classes[flat.name] = flat
+
+    return out
+
+
+def _flatten_slot(
+    slot: SlotDefinition,
+    schema_view: SchemaView,
+    dispatch_subclass: str | None = None,
+) -> Iterable[SlotDefinition]:
+    """Yield one or more flat SlotDefinitions for a single source slot.
+
+    ``dispatch_subclass`` marks the resulting slot(s) as coming from a
+    polymorphic-dispatch path so the output schema can distinguish them.
+    """
+    range_class = _range_class(slot, schema_view)
+    notes: list[str] = []
+    if dispatch_subclass:
+        notes.append(DISPATCH_NOTE.format(subclass=dispatch_subclass))
+
+    # Class range, not inlined → reference (string)
+    if range_class is not None and not _is_inlined(slot, schema_view):
+        yield _flat_string_slot(
+            slot.name,
+            slot,
+            description=(slot.description or "")
+            + (" " if slot.description else "")
+            + REF_NOTE.format(range=slot.range)
+            + (" " + LIST_JOIN_NOTE if slot.multivalued else ""),
+            required_override=(slot.required if not dispatch_subclass else False),
+            notes=notes,
+        )
+        return
+
+    # Scalar range
+    if range_class is None:
+        description = slot.description or ""
+        if slot.multivalued:
+            description = (description + " " + LIST_JOIN_NOTE).strip()
+            yield _flat_string_slot(
+                slot.name,
+                slot,
+                description=description,
+                required_override=(slot.required if not dispatch_subclass else False),
+                notes=notes,
+            )
+        else:
+            new_slot = SlotDefinition(
+                name=slot.name,
+                range=slot.range,
+                description=description or None,
+                required=(slot.required if not dispatch_subclass else False),
+            )
+            _attach_notes(new_slot, notes)
+            yield new_slot
+        return
+
+    # Class range, inlined
+    if slot.multivalued:
+        # Helper-table case — deferred.
+        return
+
+    # Single-valued inlined class → expand one level (and one more for
+    # nested controlled terms), producing <parent>_<inner> slots.
+    for inner_slot in schema_view.class_induced_slots(range_class.name):
+        if inner_slot.name == "type":
+            continue
+        inner_range = _range_class(inner_slot, schema_view)
+        if inner_range is None:
+            flat_name = f"{slot.name}_{inner_slot.name}"
+            inner_description = inner_slot.description or ""
+            if inner_slot.multivalued:
+                description = (
+                    inner_description
+                    + " "
+                    + NESTED_NOTE.format(parent=slot.name, inner=inner_slot.name)
+                    + " "
+                    + LIST_JOIN_NOTE
+                ).strip()
+                yield _flat_string_slot(
+                    flat_name,
+                    inner_slot,
+                    description=description,
+                    required_override=False,
+                    notes=notes,
+                )
+            else:
+                new_slot = SlotDefinition(
+                    name=flat_name,
+                    range=inner_slot.range,
+                    description=(
+                        (inner_description + " " + NESTED_NOTE.format(parent=slot.name, inner=inner_slot.name)).strip()
+                    ),
+                    required=False,
+                )
+                _attach_notes(new_slot, notes)
+                yield new_slot
+            continue
+        # One more level of nesting (term → id/name)
+        if not inner_slot.multivalued:
+            for deepest in schema_view.class_induced_slots(inner_range.name):
+                if deepest.name == "type":
+                    continue
+                if _range_class(deepest, schema_view) is not None:
+                    continue  # Three levels deep is out of scope
+                flat_name = f"{slot.name}_{inner_slot.name}_{deepest.name}"
+                deep_description = deepest.description or ""
+                if deepest.multivalued:
+                    description = (
+                        deep_description
+                        + " "
+                        + NESTED_NOTE.format(
+                            parent=f"{slot.name}.{inner_slot.name}",
+                            inner=deepest.name,
+                        )
+                        + " "
+                        + LIST_JOIN_NOTE
+                    ).strip()
+                    yield _flat_string_slot(
+                        flat_name,
+                        deepest,
+                        description=description,
+                        required_override=False,
+                        notes=notes,
+                    )
+                else:
+                    new_slot = SlotDefinition(
+                        name=flat_name,
+                        range=deepest.range,
+                        description=(
+                            (
+                                deep_description
+                                + " "
+                                + NESTED_NOTE.format(
+                                    parent=f"{slot.name}.{inner_slot.name}",
+                                    inner=deepest.name,
+                                )
+                            ).strip()
+                        ),
+                        required=False,
+                    )
+                    _attach_notes(new_slot, notes)
+                    yield new_slot
+
+
+def _range_class(slot: SlotDefinition, schema_view: SchemaView):
+    """Return the class range of a slot, or None if the range is a type/enum."""
+    if not slot.range:
+        return None
+    return schema_view.get_class(slot.range)
+
+
+def _flat_string_slot(
+    name: str,
+    source: SlotDefinition,
+    description: str,
+    required_override: bool | None,
+    notes: list[str],
+) -> SlotDefinition:
+    """Construct a flat SlotDefinition with a string range."""
+    slot = SlotDefinition(
+        name=name,
+        range="string",
+        description=description or None,
+        required=required_override,
+    )
+    _attach_notes(slot, notes)
+    return slot
+
+
+def _attach_notes(slot: SlotDefinition, notes: list[str]) -> None:
+    """Append notes to the slot's description (semicolon-separated)."""
+    if not notes:
+        return
+    extra = "; ".join(notes)
+    slot.description = f"{slot.description}. {extra}" if slot.description else extra
+
+
+def _proper_descendants(schema_view: SchemaView, class_name: str) -> list[str]:
+    """Return descendants of ``class_name`` excluding itself.
+
+    Uses ``class_descendants`` which LinkML returns inclusive of the root.
+    """
+    try:
+        descendants = schema_view.class_descendants(class_name)
+    except Exception:
+        return []
+    return [d for d in descendants if d != class_name]

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -1,0 +1,157 @@
+"""Tests for the schema_generator.
+
+Uses the same hand-crafted LinkML schema shape as test_flatteners — keeps
+the generator and the runtime flattener honest about producing the same
+column names.
+"""
+
+from __future__ import annotations
+
+import pytest
+from linkml_runtime import SchemaView
+
+from nmdc_lakehouse.transforms.schema_generator import (
+    flatten_class_def,
+    flatten_database_schema,
+)
+
+_SCHEMA_YAML = """
+id: https://example.org/test
+name: test_schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+
+classes:
+  Term:
+    attributes:
+      id:
+        identifier: true
+        required: true
+      name:
+
+  ControlledTermValue:
+    attributes:
+      has_raw_value:
+      term:
+        range: Term
+
+  TextValue:
+    attributes:
+      has_raw_value:
+
+  Process:
+    attributes:
+      id:
+        required: true
+      type:
+  Pooling:
+    is_a: Process
+    attributes:
+      pooling_method:
+  Extraction:
+    is_a: Process
+    attributes:
+      extraction_targets:
+        multivalued: true
+
+  Record:
+    attributes:
+      id:
+        required: true
+      name:
+      depth:
+      tags:
+        multivalued: true
+      env_broad_scale:
+        range: ControlledTermValue
+        inlined: true
+      description:
+        range: TextValue
+        inlined: true
+      associated_studies:
+        range: Term
+        multivalued: true
+      parent:
+        range: Term
+
+  Database:
+    tree_root: true
+    attributes:
+      record_set:
+        range: Record
+        multivalued: true
+      process_set:
+        range: Process
+        multivalued: true
+"""
+
+
+@pytest.fixture
+def sv() -> SchemaView:
+    return SchemaView(_SCHEMA_YAML)
+
+
+def test_flat_class_includes_scalar_slots(sv):
+    """Scalar slots become flat slots with the same range."""
+    flat = flatten_class_def(sv, "Record")
+    assert "id" in flat.attributes
+    assert flat.attributes["id"].range == "string"
+    assert "name" in flat.attributes
+
+
+def test_flat_class_pipe_joins_multivalued_scalar(sv):
+    """Multivalued scalar slots become a single string slot, with note."""
+    flat = flatten_class_def(sv, "Record")
+    tags = flat.attributes["tags"]
+    assert tags.range == "string"
+    assert "pipe-separated" in (tags.description or "")
+
+
+def test_flat_class_treats_class_ref_as_scalar(sv):
+    """Slot with class range and an identifier is a string ID column."""
+    flat = flatten_class_def(sv, "Record")
+    parent = flat.attributes["parent"]
+    assert parent.range == "string"
+    assert "Reference by identifier" in (parent.description or "")
+
+
+def test_flat_class_expands_inlined_object(sv):
+    """Single-valued inlined class slot expands to <slot>_<subslot>."""
+    flat = flatten_class_def(sv, "Record")
+    assert "description_has_raw_value" in flat.attributes
+    assert "env_broad_scale_has_raw_value" in flat.attributes
+    # Two-level expansion through controlled term's term.id
+    assert "env_broad_scale_term_id" in flat.attributes
+
+
+def test_flat_class_unions_subclass_slots(sv):
+    """Polymorphic dispatch: subclass slots appear on the base flat class."""
+    flat = flatten_class_def(sv, "Process")
+    # Pooling-only and Extraction-only slots both present
+    assert "pooling_method" in flat.attributes
+    assert "extraction_targets" in flat.attributes
+    # Subclass slots are non-required (sparse columns)
+    assert flat.attributes["pooling_method"].required is False
+
+
+def test_flat_class_subclass_slots_carry_dispatch_note(sv):
+    """Subclass slots are tagged with the source subclass in description."""
+    flat = flatten_class_def(sv, "Process")
+    desc = flat.attributes["pooling_method"].description or ""
+    assert "Pooling" in desc
+
+
+def test_flatten_database_schema_yields_one_class_per_collection(sv):
+    """Walking Database produces one flat class per multivalued slot."""
+    out = flatten_database_schema(sv, database_class="Database")
+    assert "RecordFlat" in out.classes
+    assert "ProcessFlat" in out.classes
+
+
+# Note: a generator/runtime consistency test ("every column flatten_record
+# emits exists in the generated class") will be added in a follow-up once
+# both #6 (flattener) and #12 (this) have landed and both helpers are in
+# the same source tree.

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -1,8 +1,7 @@
 """Tests for the schema_generator.
 
-Uses the same hand-crafted LinkML schema shape as test_flatteners — keeps
-the generator and the runtime flattener honest about producing the same
-column names.
+Uses a hand-crafted LinkML schema that exercises the shapes needed to
+validate generated flattened column names and related slot behavior.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #12.

`flatten_database_schema` walks the 17 `Database` slots and emits a `ClassDefinition` per collection whose attributes mirror what `SchemaDrivenFlattener` produces. For polymorphic base classes, the flat class contains the union of all concrete subclass slots (non-required), matching the squad proposal's "NMDC-schema → transform spec → NMDC-schema-flattened" deliverable.

`just generate-flat-schema` writes `./local/nmdc_schema_flattened.yaml`. Generated schema round-trips through `SchemaView`. 7 unit tests against a hand-crafted schema.

A generator/runtime consistency test will land once #6 and this are merged. See #14 for the related idea of emitting a `linkml-map` spec from this same generator.