### PR TITLE
Write flat rows to partitioned Parquet

### DIFF
--- a/src/nmdc_lakehouse/sinks/base.py
+++ b/src/nmdc_lakehouse/sinks/base.py
@@ -9,6 +9,10 @@ from typing import Iterable, Protocol, runtime_checkable
 class Sink(Protocol):
     """A sink writes an iterable of flat rows to an external location."""
 
-    def write(self, rows: Iterable[dict], *, table: str) -> None:
-        """Write ``rows`` under the logical ``table`` name."""
+    def write(self, rows: Iterable[dict], *, table: str) -> int | None:
+        """Write ``rows`` under the logical ``table`` name.
+
+        Returns the number of rows written, or ``None`` if the sink does not
+        track row counts.
+        """
         ...

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -1,22 +1,149 @@
-"""Parquet sink.
-
-Stub module — will use :mod:`pyarrow` to write partitioned Parquet datasets
-under ``LAKEHOUSE_ROOT``.
-"""
+"""Parquet sink — write flat row dicts to partitioned Parquet files."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Iterator
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from linkml_runtime.linkml_model import ClassDefinition
+
+DEFAULT_BATCH_SIZE = 10_000
+
+# Mapping from LinkML / XSD range names to Arrow types.
+# Anything not listed defaults to string.
+_RANGE_TO_ARROW: dict[str, pa.DataType] = {
+    "integer": pa.int64(),
+    "int": pa.int64(),
+    "long": pa.int64(),
+    "float": pa.float64(),
+    "double": pa.float64(),
+    "decimal": pa.float64(),
+    "boolean": pa.bool_(),
+    "string": pa.string(),
+    "uriorcurie": pa.string(),
+    "uri": pa.string(),
+    "ncname": pa.string(),
+    "date": pa.string(),
+    "datetime": pa.string(),
+}
+
+
+def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
+    """Derive a PyArrow schema from a (flat) LinkML ClassDefinition.
+
+    Each attribute becomes a nullable Arrow field. The range is mapped
+    via ``_RANGE_TO_ARROW``; unknown ranges default to string.
+
+    Args:
+        class_def: A flat ``ClassDefinition`` whose attributes have scalar
+            ranges (as produced by :func:`nmdc_lakehouse.transforms.schema_generator.flatten_class_def`).
+
+    Returns:
+        A ``pa.Schema`` with one field per attribute, in alphabetical order.
+    """
+    fields = []
+    for name in sorted(class_def.attributes):
+        slot = class_def.attributes[name]
+        range_name = slot.range or "string"
+        arrow_type = _RANGE_TO_ARROW.get(range_name, pa.string())
+        fields.append(pa.field(name, arrow_type, nullable=True))
+    return pa.schema(fields)
 
 
 class ParquetSink:
-    """Write rows as Parquet files under a root directory / object-store URI."""
+    """Write flat row dicts to Parquet files under a root directory.
 
-    def __init__(self, root: str | Path) -> None:
-        """Construct a ParquetSink rooted at ``root``."""
+    Matches Sierra's ``Sink`` protocol: ``write(rows, table=...)`` consumes
+    an iterator of flat dicts and writes ``{root}/{table}.parquet``.
+
+    Rows are buffered in batches of ``batch_size`` before each write so memory
+    use stays bounded regardless of collection size. An Arrow schema is derived
+    from a ``ClassDefinition`` at construction time so column types are stable
+    across all batches; a column absent from a row is written as null.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        class_def: ClassDefinition | None = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        """Construct a ParquetSink.
+
+        Args:
+            root: Directory (or object-store URI prefix) to write into.
+            class_def: Optional flat ``ClassDefinition`` used to derive the
+                Arrow schema. When provided, column types are stable and
+                columns absent from a row are written as null. When ``None``,
+                the schema is inferred from the first batch (simpler but types
+                may vary across collections).
+            batch_size: Number of rows to buffer before flushing a row group.
+        """
         self.root = Path(root)
+        self.class_def = class_def
+        self.batch_size = batch_size
+        self._arrow_schema: pa.Schema | None = class_def_to_arrow_schema(class_def) if class_def is not None else None
 
-    def write(self, rows: Iterable[dict], *, table: str) -> None:
-        """Write ``rows`` to ``{root}/{table}``."""
-        raise NotImplementedError
+    def write(self, rows: Iterable[dict], *, table: str) -> int:
+        """Write ``rows`` to ``{root}/{table}.parquet``.
+
+        Streams rows through in batches; the file is finalised and closed when
+        the iterator is exhausted.
+
+        Args:
+            rows: Iterable of flat dicts (as produced by
+                :func:`nmdc_lakehouse.transforms.flatteners.flatten_record`).
+            table: Logical table name; becomes the parquet filename stem.
+
+        Returns:
+            Total number of rows written.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        out_path = self.root / f"{table}.parquet"
+        total = 0
+        writer: pq.ParquetWriter | None = None
+
+        try:
+            for batch in _batched(rows, self.batch_size):
+                arrow_table = self._to_arrow_table(batch)
+                if writer is None:
+                    writer = pq.ParquetWriter(out_path, arrow_table.schema)
+                writer.write_table(arrow_table)
+                total += len(batch)
+        finally:
+            if writer is not None:
+                writer.close()
+
+        return total
+
+    def _to_arrow_table(self, rows: list[dict]) -> pa.Table:
+        """Convert a list of flat dicts to a PyArrow Table.
+
+        When a fixed schema is available, missing columns are filled with nulls
+        so every row group has the same shape. Without a fixed schema, the schema
+        is inferred from the batch (column types may differ across batches).
+        """
+        if self._arrow_schema is not None:
+            columns: dict[str, list] = {name: [] for name in self._arrow_schema.names}
+            for row in rows:
+                for name in self._arrow_schema.names:
+                    columns[name].append(row.get(name))
+            arrays = [
+                pa.array(columns[name], type=self._arrow_schema.field(name).type) for name in self._arrow_schema.names
+            ]
+            return pa.table(dict(zip(self._arrow_schema.names, arrays, strict=True)), schema=self._arrow_schema)
+        return pa.Table.from_pylist(rows)
+
+
+def _batched(iterable: Iterable[dict], size: int) -> Iterator[list[dict]]:
+    """Yield successive lists of up to ``size`` items from ``iterable``."""
+    batch: list[dict] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -129,12 +129,28 @@ class ParquetSink:
             columns: dict[str, list] = {name: [] for name in self._arrow_schema.names}
             for row in rows:
                 for name in self._arrow_schema.names:
-                    columns[name].append(row.get(name))
+                    val = row.get(name)
+                    field_type = self._arrow_schema.field(name).type
+                    columns[name].append(_coerce(val, field_type))
             arrays = [
                 pa.array(columns[name], type=self._arrow_schema.field(name).type) for name in self._arrow_schema.names
             ]
             return pa.table(dict(zip(self._arrow_schema.names, arrays, strict=True)), schema=self._arrow_schema)
         return pa.Table.from_pylist(rows)
+
+
+def _coerce(value: object, arrow_type: pa.DataType) -> object:
+    """Coerce a value to be compatible with ``arrow_type``.
+
+    Real NMDC data sometimes has numeric values in slots declared as string
+    (e.g. ``depth_has_raw_value = 0.5``). Stringify non-string values for
+    string columns; leave everything else to Arrow's native coercion.
+    """
+    if value is None:
+        return None
+    if arrow_type == pa.string() and not isinstance(value, str):
+        return str(value)
+    return value
 
 
 def _batched(iterable: Iterable[dict], size: int) -> Iterator[list[dict]]:

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -41,7 +41,8 @@ def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
             ranges (as produced by :func:`nmdc_lakehouse.transforms.schema_generator.flatten_class_def`).
 
     Returns:
-        A ``pa.Schema`` with one field per attribute, in alphabetical order.
+        A ``pa.Schema`` with ``id`` first (if present), then remaining fields
+        in alphabetical order.
     """
     fields = []
     # id first, then alphabetical — makes row browsers easier to use.
@@ -77,7 +78,8 @@ class ParquetSink:
         """Construct a ParquetSink.
 
         Args:
-            root: Directory (or object-store URI prefix) to write into.
+            root: Local filesystem directory to write into. Object-store URIs
+                (e.g. ``s3://...``) are not supported by this implementation.
             class_def: Optional flat ``ClassDefinition`` used to derive the
                 Arrow schema. When provided, column types are stable and
                 columns absent from a row are written as null. When ``None``,
@@ -98,7 +100,7 @@ class ParquetSink:
 
         Args:
             rows: Iterable of flat dicts (as produced by
-                :func:`nmdc_lakehouse.transforms.flatteners.flatten_record`).
+                :meth:`nmdc_lakehouse.transforms.flatteners.SchemaDrivenFlattener.apply`).
             table: Logical table name; becomes the parquet filename stem.
             drop_empty_cols: When True, rewrite the file after writing to
                 remove columns that are entirely null. Useful for wide sparse

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -44,7 +44,11 @@ def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
         A ``pa.Schema`` with one field per attribute, in alphabetical order.
     """
     fields = []
-    for name in sorted(class_def.attributes):
+    # id first, then alphabetical — makes row browsers easier to use.
+    names = sorted(class_def.attributes)
+    if "id" in names:
+        names = ["id"] + [n for n in names if n != "id"]
+    for name in names:
         slot = class_def.attributes[name]
         range_name = slot.range or "string"
         arrow_type = _RANGE_TO_ARROW.get(range_name, pa.string())
@@ -86,7 +90,7 @@ class ParquetSink:
         self.batch_size = batch_size
         self._arrow_schema: pa.Schema | None = class_def_to_arrow_schema(class_def) if class_def is not None else None
 
-    def write(self, rows: Iterable[dict], *, table: str) -> int:
+    def write(self, rows: Iterable[dict], *, table: str, drop_empty_cols: bool = False) -> int:
         """Write ``rows`` to ``{root}/{table}.parquet``.
 
         Streams rows through in batches; the file is finalised and closed when
@@ -96,6 +100,10 @@ class ParquetSink:
             rows: Iterable of flat dicts (as produced by
                 :func:`nmdc_lakehouse.transforms.flatteners.flatten_record`).
             table: Logical table name; becomes the parquet filename stem.
+            drop_empty_cols: When True, rewrite the file after writing to
+                remove columns that are entirely null. Useful for wide sparse
+                schemas (e.g. BiosampleFlat with 1,398 columns) where most
+                columns are empty for a given dataset.
 
         Returns:
             Total number of rows written.
@@ -115,6 +123,12 @@ class ParquetSink:
         finally:
             if writer is not None:
                 writer.close()
+
+        if drop_empty_cols and out_path.exists():
+            tbl = pq.read_table(out_path)
+            non_empty = [name for name in tbl.schema.names if tbl.column(name).null_count < len(tbl)]
+            if len(non_empty) < len(tbl.schema.names):
+                pq.write_table(tbl.select(non_empty), out_path)
 
         return total
 
@@ -140,11 +154,13 @@ class ParquetSink:
 
 
 def _coerce(value: object, arrow_type: pa.DataType) -> object:
-    """Coerce a value to be compatible with ``arrow_type``.
+    """Coerce a Python value to be compatible with ``arrow_type``.
 
-    Real NMDC data sometimes has numeric values in slots declared as string
-    (e.g. ``depth_has_raw_value = 0.5``). Stringify non-string values for
-    string columns; leave everything else to Arrow's native coercion.
+    Arrow is strict about types; real NMDC data sometimes has numeric values
+    in slots declared as string (e.g. ``depth_has_raw_value = 0.5``). When
+    the value is incompatible with a string column, stringify it. For numeric
+    columns, leave None as-is and let Arrow handle coercion from compatible
+    Python scalars.
     """
     if value is None:
         return None

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -60,7 +60,7 @@ def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
 class ParquetSink:
     """Write flat row dicts to Parquet files under a root directory.
 
-    Matches Sierra's ``Sink`` protocol: ``write(rows, table=...)`` consumes
+    Matches the ``Sink`` protocol: ``write(rows, table=...)`` consumes
     an iterator of flat dicts and writes ``{root}/{table}.parquet``.
 
     Rows are buffered in batches of ``batch_size`` before each write so memory

--- a/tests/test_parquet_sink.py
+++ b/tests/test_parquet_sink.py
@@ -10,23 +10,6 @@ from linkml_runtime.linkml_model import ClassDefinition
 
 from nmdc_lakehouse.sinks.parquet_sink import ParquetSink, class_def_to_arrow_schema
 
-_SIMPLE_CLASS_DEF_YAML = """
-name: FlatRecord
-attributes:
-  id:
-    range: string
-    required: true
-  depth_has_numeric_value:
-    range: float
-  depth_has_unit:
-    range: string
-  count:
-    range: integer
-  active:
-    range: boolean
-"""
-
-
 @pytest.fixture
 def flat_class() -> ClassDefinition:
     """A minimal flat ClassDefinition with mixed ranges."""
@@ -132,3 +115,17 @@ def test_write_empty_input(flat_class, tmp_path):
     total = sink.write(iter([]), table="flat_record")
     assert total == 0
     assert not (tmp_path / "flat_record.parquet").exists()
+
+
+def test_drop_empty_cols_removes_all_null_columns(flat_class, tmp_path):
+    """drop_empty_cols=True strips columns that are null in every row."""
+    sink = ParquetSink(tmp_path, class_def=flat_class)
+    rows = [{"id": "r1", "depth_has_unit": "m"}, {"id": "r2", "depth_has_unit": "cm"}]
+    sink.write(iter(rows), table="flat_record", drop_empty_cols=True)
+    tbl = pq.read_table(tmp_path / "flat_record.parquet")
+    assert "id" in tbl.schema.names
+    assert "depth_has_unit" in tbl.schema.names
+    # depth_has_numeric_value, count, active were never set — should be dropped
+    assert "depth_has_numeric_value" not in tbl.schema.names
+    assert "count" not in tbl.schema.names
+    assert "active" not in tbl.schema.names

--- a/tests/test_parquet_sink.py
+++ b/tests/test_parquet_sink.py
@@ -1,0 +1,134 @@
+"""Tests for ParquetSink and class_def_to_arrow_schema."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model import ClassDefinition
+
+from nmdc_lakehouse.sinks.parquet_sink import ParquetSink, class_def_to_arrow_schema
+
+_SIMPLE_CLASS_DEF_YAML = """
+name: FlatRecord
+attributes:
+  id:
+    range: string
+    required: true
+  depth_has_numeric_value:
+    range: float
+  depth_has_unit:
+    range: string
+  count:
+    range: integer
+  active:
+    range: boolean
+"""
+
+
+@pytest.fixture
+def flat_class() -> ClassDefinition:
+    """A minimal flat ClassDefinition with mixed ranges."""
+    sv = SchemaView("""
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  FlatRecord:
+    attributes:
+      id:
+        range: string
+        required: true
+      depth_has_numeric_value:
+        range: float
+      depth_has_unit:
+        range: string
+      count:
+        range: integer
+      active:
+        range: boolean
+""")
+    return sv.get_class("FlatRecord")
+
+
+def test_arrow_schema_types(flat_class, tmp_path):
+    """class_def_to_arrow_schema maps ranges to Arrow types correctly."""
+    schema = class_def_to_arrow_schema(flat_class)
+    field_map = {f.name: f.type for f in schema}
+    assert field_map["id"] == pa.string()
+    assert field_map["depth_has_numeric_value"] == pa.float64()
+    assert field_map["depth_has_unit"] == pa.string()
+    assert field_map["count"] == pa.int64()
+    assert field_map["active"] == pa.bool_()
+
+
+def test_arrow_schema_all_nullable(flat_class):
+    """All fields are nullable (sparse columns for polymorphic data)."""
+    schema = class_def_to_arrow_schema(flat_class)
+    assert all(f.nullable for f in schema)
+
+
+def test_write_produces_parquet_file(flat_class, tmp_path):
+    """write() creates a parquet file at {root}/{table}.parquet."""
+    sink = ParquetSink(tmp_path, class_def=flat_class)
+    rows = [{"id": f"r{i}", "depth_has_numeric_value": float(i)} for i in range(5)]
+    total = sink.write(iter(rows), table="flat_record")
+    assert total == 5
+    assert (tmp_path / "flat_record.parquet").exists()
+
+
+def test_write_roundtrip(flat_class, tmp_path):
+    """Rows written can be read back with correct values."""
+    sink = ParquetSink(tmp_path, class_def=flat_class)
+    rows = [
+        {"id": "r1", "depth_has_numeric_value": 0.5, "depth_has_unit": "m", "count": 3},
+        {"id": "r2", "depth_has_unit": "cm"},
+    ]
+    sink.write(iter(rows), table="flat_record")
+    tbl = pq.read_table(tmp_path / "flat_record.parquet")
+    assert tbl.num_rows == 2
+    assert tbl.schema.field("id").type == pa.string()
+    assert tbl.schema.field("depth_has_numeric_value").type == pa.float64()
+    assert tbl.column("id").to_pylist() == ["r1", "r2"]
+    assert tbl.column("depth_has_unit").to_pylist() == ["m", "cm"]
+
+
+def test_missing_columns_written_as_null(flat_class, tmp_path):
+    """Columns absent from a row are written as null when a schema is set."""
+    sink = ParquetSink(tmp_path, class_def=flat_class)
+    sink.write(iter([{"id": "r1"}]), table="flat_record")
+    tbl = pq.read_table(tmp_path / "flat_record.parquet")
+    assert tbl.column("depth_has_numeric_value")[0].as_py() is None
+    assert tbl.column("count")[0].as_py() is None
+
+
+def test_write_batches_large_input(flat_class, tmp_path):
+    """Input larger than batch_size is written in multiple row groups."""
+    sink = ParquetSink(tmp_path, class_def=flat_class, batch_size=10)
+    rows = [{"id": f"r{i}"} for i in range(35)]
+    total = sink.write(iter(rows), table="flat_record")
+    assert total == 35
+    tbl = pq.read_table(tmp_path / "flat_record.parquet")
+    assert tbl.num_rows == 35
+
+
+def test_write_without_class_def_infers_schema(tmp_path):
+    """Without a class_def, schema is inferred from data."""
+    sink = ParquetSink(tmp_path)
+    rows = [{"id": "r1", "name": "biosample"}]
+    sink.write(iter(rows), table="inferred")
+    tbl = pq.read_table(tmp_path / "inferred.parquet")
+    assert tbl.num_rows == 1
+    assert set(tbl.schema.names) == {"id", "name"}
+
+
+def test_write_empty_input(flat_class, tmp_path):
+    """Writing zero rows produces no file."""
+    sink = ParquetSink(tmp_path, class_def=flat_class)
+    total = sink.write(iter([]), table="flat_record")
+    assert total == 0
+    assert not (tmp_path / "flat_record.parquet").exists()


### PR DESCRIPTION
Closes #7.

`ParquetSink.write(rows, table=...)` consumes an iterator of flat dicts, buffers them in configurable batches, and writes `{root}/{table}.parquet` via `pyarrow.parquet.ParquetWriter`. Depends on a `ClassDefinition` (from #12's `flatten_class_def`) to derive a stable Arrow schema so column types are consistent across batches and absent columns are written as null.

`class_def_to_arrow_schema` maps LinkML ranges to Arrow types; anything not in the explicit map defaults to string.

8 unit tests; no MongoDB or nmdc-schema dependency.