### PR TITLE
End-to-end job: NMDC biosamples to Parquet

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,6 +68,10 @@ cli *ARGS:
 run-job JOB *ARGS:
     uv run nmdc-lakehouse run-job {{JOB}} {{ARGS}}
 
+# Delete every generated Parquet file under ./local/parquet/.
+clean-parquet:
+    rm -rf ./local/parquet/*
+
 # ---------- Docs ----------
 
 # Serve documentation locally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,8 @@ markers = [
 python_version = "3.10"
 warn_unused_ignores = true
 ignore_missing_imports = true
+
+[dependency-groups]
+dev = [
+    "types-pyyaml>=6.0.12.20260408",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "ruff>=0.5",
     "mypy>=1.10",
     "pre-commit>=3.7",
+    "types-PyYAML>=6.0.12.20260408",
 ]
 docs = [
     "mkdocs>=1.6",
@@ -118,8 +119,3 @@ markers = [
 python_version = "3.10"
 warn_unused_ignores = true
 ignore_missing_imports = true
-
-[dependency-groups]
-dev = [
-    "types-pyyaml>=6.0.12.20260408",
-]

--- a/src/nmdc_lakehouse/cli.py
+++ b/src/nmdc_lakehouse/cli.py
@@ -11,6 +11,9 @@ import logging
 
 import click
 
+import nmdc_lakehouse.jobs  # noqa: F401 — registers all built-in jobs
+from nmdc_lakehouse.jobs.registry import get, list_names
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -24,8 +27,8 @@ def cli() -> None:
 @cli.command("list-jobs")
 def list_jobs() -> None:
     """List all ETL jobs registered with the runner."""
-    # Implementation will enumerate nmdc_lakehouse.jobs.registry once jobs exist.
-    raise NotImplementedError
+    for name in list_names():
+        click.echo(name)
 
 
 @cli.command("run-job")
@@ -33,7 +36,12 @@ def list_jobs() -> None:
 @click.option("--dry-run", is_flag=True, help="Plan the job but do not write output.")
 def run_job(job_name: str, dry_run: bool) -> None:
     """Run a named ETL job from the registry."""
-    raise NotImplementedError
+    job = get(job_name)
+    result = job.run(dry_run=dry_run)
+    click.echo(f"rows_read={result.rows_read}")
+    click.echo(f"rows_written={result.rows_written}")
+    if result.tables_written:
+        click.echo(f"tables={', '.join(result.tables_written)}")
 
 
 if __name__ == "__main__":

--- a/src/nmdc_lakehouse/cli.py
+++ b/src/nmdc_lakehouse/cli.py
@@ -40,12 +40,20 @@ def list_jobs() -> None:
     envvar="LAKEHOUSE_DROP_EMPTY_COLS",
     help="Remove all-null columns from the output Parquet file.",
 )
-def run_job(job_name: str, dry_run: bool, drop_empty_cols: bool) -> None:
+@click.option(
+    "--skip",
+    "skip",
+    multiple=True,
+    help="Collection to skip (repeatable). Only honored by 'all-collections'.",
+)
+def run_job(job_name: str, dry_run: bool, drop_empty_cols: bool, skip: tuple[str, ...]) -> None:
     """Run a named ETL job from the registry."""
     import os
 
     if drop_empty_cols:
         os.environ["LAKEHOUSE_DROP_EMPTY_COLS"] = "true"
+    if skip:
+        os.environ["LAKEHOUSE_SKIP_COLLECTIONS"] = ",".join(skip)
     job = get(job_name)
     result = job.run(dry_run=dry_run)
     click.echo(f"rows_read={result.rows_read}")

--- a/src/nmdc_lakehouse/cli.py
+++ b/src/nmdc_lakehouse/cli.py
@@ -34,8 +34,18 @@ def list_jobs() -> None:
 @cli.command("run-job")
 @click.argument("job_name")
 @click.option("--dry-run", is_flag=True, help="Plan the job but do not write output.")
-def run_job(job_name: str, dry_run: bool) -> None:
+@click.option(
+    "--drop-empty-cols",
+    is_flag=True,
+    envvar="LAKEHOUSE_DROP_EMPTY_COLS",
+    help="Remove all-null columns from the output Parquet file.",
+)
+def run_job(job_name: str, dry_run: bool, drop_empty_cols: bool) -> None:
     """Run a named ETL job from the registry."""
+    import os
+
+    if drop_empty_cols:
+        os.environ["LAKEHOUSE_DROP_EMPTY_COLS"] = "true"
     job = get(job_name)
     result = job.run(dry_run=dry_run)
     click.echo(f"rows_read={result.rows_read}")

--- a/src/nmdc_lakehouse/jobs/__init__.py
+++ b/src/nmdc_lakehouse/jobs/__init__.py
@@ -5,4 +5,8 @@ A job wires a :class:`~nmdc_lakehouse.sources.base.Source`, one or more
 :class:`~nmdc_lakehouse.sinks.base.Sink` into a runnable unit. Jobs are
 registered in :mod:`nmdc_lakehouse.jobs.registry` and dispatched by
 :mod:`nmdc_lakehouse.cli` (or by an external orchestrator).
+
+Importing this package registers all built-in jobs.
 """
+
+from nmdc_lakehouse.jobs import biosample_to_parquet as _  # noqa: F401

--- a/src/nmdc_lakehouse/jobs/__init__.py
+++ b/src/nmdc_lakehouse/jobs/__init__.py
@@ -10,3 +10,4 @@ Importing this package registers all built-in jobs.
 """
 
 from nmdc_lakehouse.jobs import biosample_to_parquet as _  # noqa: F401
+from nmdc_lakehouse.jobs import collection_to_parquet as __  # noqa: F401

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -1,0 +1,110 @@
+"""ETL job: flatten NMDC biosample_set and write to Parquet.
+
+This is the first concrete job in the nmdc-lakehouse pipeline.
+It wires together the three core components:
+
+  MongoSource  →  SchemaDrivenFlattener  →  ParquetSink
+
+and is registered under the name ``"biosamples-to-parquet"`` so it can be
+dispatched via ``nmdc-lakehouse run-job biosamples-to-parquet``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from nmdc_lakehouse.jobs.base import Job, JobResult
+from nmdc_lakehouse.jobs.registry import register
+from nmdc_lakehouse.sinks.parquet_sink import ParquetSink
+from nmdc_lakehouse.sources.mongo_source import MongoSource
+from nmdc_lakehouse.transforms.flatteners import SchemaDrivenFlattener
+
+_COLLECTION = "biosample_set"
+_ROOT_CLASS = "Biosample"
+
+
+@register("biosamples-to-parquet")
+def _factory() -> "BiosampleToParquetJob":
+    """Construct a BiosampleToParquetJob from environment variables."""
+    mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
+    out_root = Path(os.environ.get("LAKEHOUSE_ROOT", "./local/parquet"))
+    return BiosampleToParquetJob(mongo_uri=mongo_uri, out_root=out_root)
+
+
+class BiosampleToParquetJob(Job):
+    """Flatten all records in ``biosample_set`` and write them to Parquet.
+
+    Reads from a local MongoDB instance (configured via ``MONGO_URI``),
+    flattens with :class:`~nmdc_lakehouse.transforms.flatteners.SchemaDrivenFlattener`
+    using the installed ``nmdc-schema``, and writes the result to
+    ``{LAKEHOUSE_ROOT}/biosample_set.parquet``.
+
+    The Arrow schema is derived from the nmdc-schema at job construction
+    time so column types are stable across all batched writes and columns
+    absent from individual records are written as null.
+    """
+
+    name = "biosamples-to-parquet"
+
+    def __init__(self, mongo_uri: str, out_root: Path) -> None:
+        """Construct the job.
+
+        Args:
+            mongo_uri: MongoDB connection URI including database name.
+            out_root: Directory to write Parquet files into.
+        """
+        self.mongo_uri = mongo_uri
+        self.out_root = out_root
+
+    def run(self, *, dry_run: bool = False) -> JobResult:
+        """Execute the job.
+
+        Streams records from MongoDB through the flattener into Parquet.
+        In dry-run mode, counts records but writes nothing.
+
+        Args:
+            dry_run: If True, measure without writing.
+
+        Returns:
+            A :class:`~nmdc_lakehouse.jobs.base.JobResult` with row counts.
+        """
+        from importlib.util import find_spec
+
+        from linkml_runtime import SchemaView
+
+        from nmdc_lakehouse.transforms.schema_generator import flatten_class_def
+
+        spec = find_spec("nmdc_schema")
+        if spec is None or not spec.submodule_search_locations:
+            raise RuntimeError("nmdc_schema package is not installed")
+        schema_path = f"{spec.submodule_search_locations[0]}/nmdc_materialized_patterns.yaml"
+        schema_view = SchemaView(schema_path)
+
+        # Stubs on main have different signatures; real implementations are in
+        # PRs #4 (MongoSource), #7 (ParquetSink), #13 (SchemaDrivenFlattener).
+        # mypy: type-ignore below silences stub mismatches until dependencies are merged.
+        source = MongoSource(self.mongo_uri)  # type: ignore
+        flattener = SchemaDrivenFlattener(schema_view, _ROOT_CLASS)
+        flat_class = flatten_class_def(schema_view, _ROOT_CLASS)
+        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
+
+        records = source.iter_records(_COLLECTION)
+        flat_rows = flattener.apply(records)
+
+        if dry_run:
+            rows_read = sum(1 for _ in flat_rows)
+            return JobResult(
+                job_name=self.name,
+                rows_read=rows_read,
+                rows_written=0,
+                tables_written=(),
+            )
+
+        rows_written: int = sink.write(flat_rows, table=_COLLECTION) or 0  # type: ignore
+        return JobResult(
+            job_name=self.name,
+            rows_read=rows_written,
+            rows_written=rows_written,
+            tables_written=(_COLLECTION,),
+        )

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -102,10 +102,18 @@ class BiosampleToParquetJob(Job):
             )
 
         drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
-        rows_written: int = sink.write(flat_rows, table=_COLLECTION, drop_empty_cols=drop_empty) or 0  # type: ignore
+        rows_read = 0
+
+        def _counted(rows):  # type: ignore[no-untyped-def]
+            nonlocal rows_read
+            for row in rows:
+                rows_read += 1
+                yield row
+
+        rows_written: int = sink.write(_counted(flat_rows), table=_COLLECTION, drop_empty_cols=drop_empty) or 0  # type: ignore
         return JobResult(
             job_name=self.name,
-            rows_read=rows_written,
+            rows_read=rows_read,
             rows_written=rows_written,
             tables_written=(_COLLECTION,),
         )

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -102,7 +102,7 @@ class BiosampleToParquetJob(Job):
             )
 
         drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
-        rows_written: int = sink.write(flat_rows, table=_COLLECTION, drop_empty_cols=drop_empty) or 0
+        rows_written: int = sink.write(flat_rows, table=_COLLECTION, drop_empty_cols=drop_empty) or 0  # type: ignore
         return JobResult(
             job_name=self.name,
             rows_read=rows_written,

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -84,10 +84,10 @@ class BiosampleToParquetJob(Job):
         # Stubs on main have different signatures; real implementations are in
         # PRs #4 (MongoSource), #7 (ParquetSink), #13 (SchemaDrivenFlattener).
         # mypy: type-ignore below silences stub mismatches until dependencies are merged.
-        source = MongoSource(self.mongo_uri)  # type: ignore
+        source = MongoSource(self.mongo_uri)
         flattener = SchemaDrivenFlattener(schema_view, _ROOT_CLASS)
         flat_class = flatten_class_def(schema_view, _ROOT_CLASS)
-        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
+        sink = ParquetSink(self.out_root, class_def=flat_class)
 
         records = source.iter_records(_COLLECTION)
         flat_rows = flattener.apply(records)
@@ -101,7 +101,8 @@ class BiosampleToParquetJob(Job):
                 tables_written=(),
             )
 
-        rows_written: int = sink.write(flat_rows, table=_COLLECTION) or 0  # type: ignore
+        drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
+        rows_written: int = sink.write(flat_rows, table=_COLLECTION, drop_empty_cols=drop_empty) or 0
         return JobResult(
             job_name=self.name,
             rows_read=rows_written,

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -84,10 +84,10 @@ class BiosampleToParquetJob(Job):
         # Stubs on main have different signatures; real implementations are in
         # PRs #4 (MongoSource), #7 (ParquetSink), #13 (SchemaDrivenFlattener).
         # mypy: type-ignore below silences stub mismatches until dependencies are merged.
-        source = MongoSource(self.mongo_uri)
+        source = MongoSource(self.mongo_uri)  # type: ignore
         flattener = SchemaDrivenFlattener(schema_view, _ROOT_CLASS)
         flat_class = flatten_class_def(schema_view, _ROOT_CLASS)
-        sink = ParquetSink(self.out_root, class_def=flat_class)
+        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
 
         records = source.iter_records(_COLLECTION)
         flat_rows = flattener.apply(records)

--- a/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/biosample_to_parquet.py
@@ -84,10 +84,10 @@ class BiosampleToParquetJob(Job):
         # Stubs on main have different signatures; real implementations are in
         # PRs #4 (MongoSource), #7 (ParquetSink), #13 (SchemaDrivenFlattener).
         # mypy: type-ignore below silences stub mismatches until dependencies are merged.
-        source = MongoSource(self.mongo_uri)  # type: ignore
+        source = MongoSource(self.mongo_uri)
         flattener = SchemaDrivenFlattener(schema_view, _ROOT_CLASS)
         flat_class = flatten_class_def(schema_view, _ROOT_CLASS)
-        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
+        sink = ParquetSink(self.out_root, class_def=flat_class)
 
         records = source.iter_records(_COLLECTION)
         flat_rows = flattener.apply(records)
@@ -104,13 +104,13 @@ class BiosampleToParquetJob(Job):
         drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
         rows_read = 0
 
-        def _counted(rows):  # type: ignore[no-untyped-def]
+        def _counted(rows):
             nonlocal rows_read
             for row in rows:
                 rows_read += 1
                 yield row
 
-        rows_written: int = sink.write(_counted(flat_rows), table=_COLLECTION, drop_empty_cols=drop_empty) or 0  # type: ignore
+        rows_written: int = sink.write(_counted(flat_rows), table=_COLLECTION, drop_empty_cols=drop_empty) or 0
         return JobResult(
             job_name=self.name,
             rows_read=rows_read,

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -1,0 +1,140 @@
+"""Generic ETL job: flatten any schema-specified NMDC collection to Parquet.
+
+Registers one named job per ``Database`` slot (e.g. ``biosample_set``,
+``study_set``, ...) plus ``all-collections`` which runs all of them in
+sequence. Collection→root-class mapping is derived from the installed
+``nmdc-schema`` at import time using the same pyyaml approach as
+``scripts/python/schema_collections.py`` — no linkml import at module load.
+
+Usage::
+
+    nmdc-lakehouse run-job biosample_set
+    nmdc-lakehouse run-job study_set
+    nmdc-lakehouse run-job all-collections [--drop-empty-cols]
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from nmdc_lakehouse.jobs.base import Job, JobResult
+from nmdc_lakehouse.jobs.registry import register
+from nmdc_lakehouse.sinks.parquet_sink import ParquetSink
+from nmdc_lakehouse.sources.mongo_source import MongoSource
+from nmdc_lakehouse.transforms.flatteners import SchemaDrivenFlattener
+
+
+def _db_collection_map() -> dict[str, str]:
+    """Return {collection_name: root_class} from the installed nmdc-schema.
+
+    Uses pyyaml only (no linkml import chain) so this is fast at module load.
+    """
+    from importlib.util import find_spec
+
+    import yaml
+
+    spec = find_spec("nmdc_schema")
+    if spec is None or not spec.submodule_search_locations:
+        return {}
+    schema_path = Path(spec.submodule_search_locations[0]) / "nmdc_materialized_patterns.yaml"
+    schema = yaml.safe_load(schema_path.read_text())
+    db_slots = schema["classes"]["Database"].get("slots", []) or []
+    top_slots = schema.get("slots", {})
+    return {name: top_slots[name]["range"] for name in db_slots if name in top_slots and "range" in top_slots[name]}
+
+
+class CollectionToParquetJob(Job):
+    """Flatten one schema-specified NMDC collection and write to Parquet."""
+
+    def __init__(self, collection: str, root_class: str, mongo_uri: str, out_root: Path) -> None:
+        """Construct the job for a single collection."""
+        self.collection = collection
+        self.root_class = root_class
+        self.mongo_uri = mongo_uri
+        self.out_root = out_root
+        self.name = collection
+
+    def run(self, *, dry_run: bool = False) -> JobResult:
+        """Stream records from MongoDB through the flattener into Parquet."""
+        from importlib.util import find_spec
+
+        from linkml_runtime import SchemaView
+
+        from nmdc_lakehouse.transforms.schema_generator import flatten_class_def
+
+        spec = find_spec("nmdc_schema")
+        if spec is None or not spec.submodule_search_locations:
+            raise RuntimeError("nmdc_schema package is not installed")
+        schema_path = f"{spec.submodule_search_locations[0]}/nmdc_materialized_patterns.yaml"
+        schema_view = SchemaView(schema_path)
+
+        source = MongoSource(self.mongo_uri)  # type: ignore
+        flattener = SchemaDrivenFlattener(schema_view, self.root_class)
+        flat_class = flatten_class_def(schema_view, self.root_class)
+        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
+
+        records = source.iter_records(self.collection)
+        flat_rows = flattener.apply(records)
+
+        if dry_run:
+            rows_read = sum(1 for _ in flat_rows)
+            return JobResult(job_name=self.name, rows_read=rows_read, rows_written=0, tables_written=())
+
+        drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
+        rows_written: int = sink.write(flat_rows, table=self.collection, drop_empty_cols=drop_empty) or 0  # type: ignore
+        return JobResult(
+            job_name=self.name,
+            rows_read=rows_written,
+            rows_written=rows_written,
+            tables_written=(self.collection,),
+        )
+
+
+class AllCollectionsToParquetJob(Job):
+    """Run CollectionToParquetJob for every schema-specified collection."""
+
+    name = "all-collections"
+
+    def __init__(self, mongo_uri: str, out_root: Path) -> None:
+        """Construct the job."""
+        self.mongo_uri = mongo_uri
+        self.out_root = out_root
+
+    def run(self, *, dry_run: bool = False) -> JobResult:
+        """Run each collection job in sequence and aggregate results."""
+        total_read = total_written = 0
+        tables: list[str] = []
+        for name, root_class in _db_collection_map().items():
+            job = CollectionToParquetJob(name, root_class, self.mongo_uri, self.out_root)
+            result = job.run(dry_run=dry_run)
+            total_read += result.rows_read
+            total_written += result.rows_written
+            tables.extend(result.tables_written)
+        return JobResult(
+            job_name=self.name,
+            rows_read=total_read,
+            rows_written=total_written,
+            tables_written=tuple(tables),
+        )
+
+
+def _make_factory(collection: str, root_class: str):
+    def _factory():
+        mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
+        out_root = Path(os.environ.get("LAKEHOUSE_ROOT", "./local/parquet"))
+        return CollectionToParquetJob(collection, root_class, mongo_uri, out_root)
+
+    return _factory
+
+
+# Register one job per Database slot at import time.
+for _collection, _root_class in _db_collection_map().items():
+    register(_collection)(_make_factory(_collection, _root_class))
+
+
+@register("all-collections")
+def _all_factory():
+    mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
+    out_root = Path(os.environ.get("LAKEHOUSE_ROOT", "./local/parquet"))
+    return AllCollectionsToParquetJob(mongo_uri, out_root)

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -69,10 +69,10 @@ class CollectionToParquetJob(Job):
         schema_path = f"{spec.submodule_search_locations[0]}/nmdc_materialized_patterns.yaml"
         schema_view = SchemaView(schema_path)
 
-        source = MongoSource(self.mongo_uri)  # type: ignore
+        source = MongoSource(self.mongo_uri)
         flattener = SchemaDrivenFlattener(schema_view, self.root_class)
         flat_class = flatten_class_def(schema_view, self.root_class)
-        sink = ParquetSink(self.out_root, class_def=flat_class)  # type: ignore
+        sink = ParquetSink(self.out_root, class_def=flat_class)
 
         records = source.iter_records(self.collection)
         flat_rows = flattener.apply(records)
@@ -84,13 +84,13 @@ class CollectionToParquetJob(Job):
         drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
         rows_read = 0
 
-        def _counted(rows):  # type: ignore[no-untyped-def]
+        def _counted(rows):
             nonlocal rows_read
             for row in rows:
                 rows_read += 1
                 yield row
 
-        rows_written: int = sink.write(_counted(flat_rows), table=self.collection, drop_empty_cols=drop_empty) or 0  # type: ignore
+        rows_written: int = sink.write(_counted(flat_rows), table=self.collection, drop_empty_cols=drop_empty) or 0
         return JobResult(
             job_name=self.name,
             rows_read=rows_read,

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -82,10 +82,18 @@ class CollectionToParquetJob(Job):
             return JobResult(job_name=self.name, rows_read=rows_read, rows_written=0, tables_written=())
 
         drop_empty = os.environ.get("LAKEHOUSE_DROP_EMPTY_COLS", "").lower() in ("1", "true", "yes")
-        rows_written: int = sink.write(flat_rows, table=self.collection, drop_empty_cols=drop_empty) or 0  # type: ignore
+        rows_read = 0
+
+        def _counted(rows):  # type: ignore[no-untyped-def]
+            nonlocal rows_read
+            for row in rows:
+                rows_read += 1
+                yield row
+
+        rows_written: int = sink.write(_counted(flat_rows), table=self.collection, drop_empty_cols=drop_empty) or 0  # type: ignore
         return JobResult(
             job_name=self.name,
-            rows_read=rows_written,
+            rows_read=rows_read,
             rows_written=rows_written,
             tables_written=(self.collection,),
         )

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -96,16 +96,25 @@ class AllCollectionsToParquetJob(Job):
 
     name = "all-collections"
 
-    def __init__(self, mongo_uri: str, out_root: Path) -> None:
-        """Construct the job."""
+    def __init__(self, mongo_uri: str, out_root: Path, skip: set[str] | None = None) -> None:
+        """Construct the job.
+
+        Args:
+            mongo_uri: MongoDB connection URI including database name.
+            out_root: Directory to write Parquet files into.
+            skip: Collection names to exclude from the run.
+        """
         self.mongo_uri = mongo_uri
         self.out_root = out_root
+        self.skip = skip or set()
 
     def run(self, *, dry_run: bool = False) -> JobResult:
         """Run each collection job in sequence and aggregate results."""
         total_read = total_written = 0
         tables: list[str] = []
         for name, root_class in _db_collection_map().items():
+            if name in self.skip:
+                continue
             job = CollectionToParquetJob(name, root_class, self.mongo_uri, self.out_root)
             result = job.run(dry_run=dry_run)
             total_read += result.rows_read
@@ -137,4 +146,6 @@ for _collection, _root_class in _db_collection_map().items():
 def _all_factory():
     mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
     out_root = Path(os.environ.get("LAKEHOUSE_ROOT", "./local/parquet"))
-    return AllCollectionsToParquetJob(mongo_uri, out_root)
+    skip_raw = os.environ.get("LAKEHOUSE_SKIP_COLLECTIONS", "")
+    skip = {s.strip() for s in skip_raw.split(",") if s.strip()}
+    return AllCollectionsToParquetJob(mongo_uri, out_root, skip=skip)

--- a/tests/test_biosample_to_parquet.py
+++ b/tests/test_biosample_to_parquet.py
@@ -1,0 +1,63 @@
+"""Tests for the biosamples-to-parquet job."""
+
+from __future__ import annotations
+
+import os
+
+import pyarrow.parquet as pq
+import pytest
+
+from nmdc_lakehouse.jobs.biosample_to_parquet import BiosampleToParquetJob
+from nmdc_lakehouse.jobs.registry import get, list_names
+
+
+def test_job_is_registered():
+    """The job is registered under 'biosamples-to-parquet'."""
+    import nmdc_lakehouse.jobs.biosample_to_parquet  # noqa: F401 — triggers registration
+
+    assert "biosamples-to-parquet" in list_names()
+
+
+def test_job_can_be_retrieved_from_registry():
+    """registry.get() returns a BiosampleToParquetJob instance."""
+    import nmdc_lakehouse.jobs.biosample_to_parquet  # noqa: F401
+
+    job = get("biosamples-to-parquet")
+    assert isinstance(job, BiosampleToParquetJob)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_DB_TESTS") != "true",
+    reason="Requires a local MongoDB and nmdc_lakehouse_prep (set ENABLE_DB_TESTS=true)",
+)
+def test_dry_run_counts_but_writes_nothing(tmp_path):
+    """dry_run=True counts records without writing a Parquet file."""
+    mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
+    job = BiosampleToParquetJob(mongo_uri=mongo_uri, out_root=tmp_path)
+    result = job.run(dry_run=True)
+
+    assert result.rows_read > 0
+    assert result.rows_written == 0
+    assert result.tables_written == ()
+    assert not list(tmp_path.glob("*.parquet"))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_DB_TESTS") != "true",
+    reason="Requires a local MongoDB and nmdc_lakehouse_prep (set ENABLE_DB_TESTS=true)",
+)
+def test_full_run_writes_parquet(tmp_path):
+    """End-to-end: fetches biosamples, flattens, writes Parquet."""
+    mongo_uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017/nmdc_lakehouse_prep")
+    job = BiosampleToParquetJob(mongo_uri=mongo_uri, out_root=tmp_path)
+    result = job.run(dry_run=False)
+
+    out = tmp_path / "biosample_set.parquet"
+    assert out.exists()
+    tbl = pq.read_table(out)
+    assert tbl.num_rows == result.rows_written
+    assert tbl.num_rows > 0
+    assert "id" in tbl.schema.names
+    assert result.tables_written == ("biosample_set",)

--- a/tests/test_collection_to_parquet.py
+++ b/tests/test_collection_to_parquet.py
@@ -15,11 +15,23 @@ def test_all_17_collections_registered():
     names = list_names()
     # The 17 schema-specified collections
     expected = {
-        "biosample_set", "calibration_set", "collecting_biosamples_from_site_set",
-        "configuration_set", "data_generation_set", "data_object_set",
-        "field_research_site_set", "functional_annotation_agg", "functional_annotation_set",
-        "genome_feature_set", "instrument_set", "manifest_set", "material_processing_set",
-        "processed_sample_set", "storage_process_set", "study_set", "workflow_execution_set",
+        "biosample_set",
+        "calibration_set",
+        "collecting_biosamples_from_site_set",
+        "configuration_set",
+        "data_generation_set",
+        "data_object_set",
+        "field_research_site_set",
+        "functional_annotation_agg",
+        "functional_annotation_set",
+        "genome_feature_set",
+        "instrument_set",
+        "manifest_set",
+        "material_processing_set",
+        "processed_sample_set",
+        "storage_process_set",
+        "study_set",
+        "workflow_execution_set",
     }
     assert expected.issubset(set(names))
 

--- a/tests/test_collection_to_parquet.py
+++ b/tests/test_collection_to_parquet.py
@@ -1,0 +1,43 @@
+"""Tests for the generic collection-to-parquet job registration."""
+
+from __future__ import annotations
+
+import nmdc_lakehouse.jobs.collection_to_parquet  # noqa: F401 — triggers registration
+from nmdc_lakehouse.jobs.collection_to_parquet import (
+    AllCollectionsToParquetJob,
+    CollectionToParquetJob,
+)
+from nmdc_lakehouse.jobs.registry import get, list_names
+
+
+def test_all_17_collections_registered():
+    """One job is registered per Database slot (17 total)."""
+    names = list_names()
+    # The 17 schema-specified collections
+    expected = {
+        "biosample_set", "calibration_set", "collecting_biosamples_from_site_set",
+        "configuration_set", "data_generation_set", "data_object_set",
+        "field_research_site_set", "functional_annotation_agg", "functional_annotation_set",
+        "genome_feature_set", "instrument_set", "manifest_set", "material_processing_set",
+        "processed_sample_set", "storage_process_set", "study_set", "workflow_execution_set",
+    }
+    assert expected.issubset(set(names))
+
+
+def test_all_collections_job_registered():
+    """'all-collections' job is registered."""
+    assert "all-collections" in list_names()
+
+
+def test_collection_job_instance():
+    """registry.get('study_set') returns a CollectionToParquetJob."""
+    job = get("study_set")
+    assert isinstance(job, CollectionToParquetJob)
+    assert job.collection == "study_set"
+    assert job.root_class == "Study"
+
+
+def test_all_collections_job_instance():
+    """registry.get('all-collections') returns an AllCollectionsToParquetJob."""
+    job = get("all-collections")
+    assert isinstance(job, AllCollectionsToParquetJob)

--- a/tests/test_collection_to_parquet.py
+++ b/tests/test_collection_to_parquet.py
@@ -53,3 +53,19 @@ def test_all_collections_job_instance():
     """registry.get('all-collections') returns an AllCollectionsToParquetJob."""
     job = get("all-collections")
     assert isinstance(job, AllCollectionsToParquetJob)
+
+
+def test_all_collections_skip_via_env(monkeypatch):
+    """LAKEHOUSE_SKIP_COLLECTIONS populates the skip set."""
+    monkeypatch.setenv("LAKEHOUSE_SKIP_COLLECTIONS", "functional_annotation_agg, study_set")
+    job = get("all-collections")
+    assert isinstance(job, AllCollectionsToParquetJob)
+    assert job.skip == {"functional_annotation_agg", "study_set"}
+
+
+def test_all_collections_skip_default_empty(monkeypatch):
+    """Unset LAKEHOUSE_SKIP_COLLECTIONS yields an empty skip set."""
+    monkeypatch.delenv("LAKEHOUSE_SKIP_COLLECTIONS", raising=False)
+    job = get("all-collections")
+    assert isinstance(job, AllCollectionsToParquetJob)
+    assert job.skip == set()

--- a/uv.lock
+++ b/uv.lock
@@ -1589,7 +1589,7 @@ wheels = [
 
 [[package]]
 name = "linkml"
-version = "1.11.0rc1"
+version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -1618,9 +1618,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/ff/1014d7216c999a8600e66233995ebd02f7d3a107c8ae2e7ba264a0fdce8f/linkml-1.11.0rc1.tar.gz", hash = "sha256:5cfec0fd7e56deb9306f16580930c1cc0ff8dfbd21fe777d26cfeefbf9555009", size = 354080 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/cf/ab84deb8130d63d9a7baa52cd88b134ea9ad2186eeb4df6cdd3b837e6058/linkml-1.9.3.tar.gz", hash = "sha256:96de208001dae5bde43092ce0f3fab61df4c85231939476dc3f93d0b5b0d4590", size = 263725 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/c6/588bb89dc586a63b578c0a8d578a497a0c160500e68f1a729357b78ab2b1/linkml-1.11.0rc1-py3-none-any.whl", hash = "sha256:5a1906c498ec15904dc0e046597701b95fde70fd95726f81f44d84ff357372e4", size = 457921 },
+    { url = "https://files.pythonhosted.org/packages/91/54/5bb8f9fd0fbdd076a631bcae7c5aa3f8c1447e04650b79e45f77fab661e4/linkml-1.9.3-py3-none-any.whl", hash = "sha256:77f2e566ce03f897bc0a9dc49d4d933a859d2a78ef56f080c9a0f8415becb884", size = 336474 },
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "linkml-runtime"
-version = "1.11.0rc1"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1658,9 +1658,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/82/d51dd204d29e3f659f2b322d25b60c19c7ffcb76dabab60418986dff9d9f/linkml_runtime-1.11.0rc1.tar.gz", hash = "sha256:4f2549a96f10ade9bd5f4920b2b1dc16b13475c4f6a5b71d2445712b68b40681", size = 504892 }
+sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/d6/c51de5856550ef5b5aff864c8d66c983df210252034a0082687dceb703df/linkml_runtime-1.11.0rc1-py3-none-any.whl", hash = "sha256:894d5afa3180e97c6947596b39c2008eee62394c33a3cea20b93c0ad6638c2e9", size = 590958 },
+    { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001 },
 ]
 
 [[package]]
@@ -2335,7 +2335,6 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "duckdb" },
-    { name = "linkml" },
     { name = "linkml-runtime" },
     { name = "linkml-store" },
     { name = "nmdc-schema" },
@@ -2369,12 +2368,16 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "types-pyyaml" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "duckdb", specifier = ">=1.0" },
-    { name = "linkml", specifier = ">=1.11.0rc1" },
-    { name = "linkml-runtime", specifier = ">=1.11.0rc1" },
+    { name = "linkml-runtime", specifier = ">=1.7" },
     { name = "linkml-store", specifier = ">=0.2.10" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
@@ -2400,6 +2403,9 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66" },
 ]
 provides-extras = ["dev", "docs"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20260408" }]
 
 [[package]]
 name = "nmdc-schema"
@@ -3039,59 +3045,59 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "24.0.0"
+version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681 },
-    { url = "https://files.pythonhosted.org/packages/1d/41/64180033d7027afce12dc96d0fe1f504c6fa112190582b458acea2399530/pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147", size = 36684260 },
-    { url = "https://files.pythonhosted.org/packages/57/02/9b9320e673dd8a99411fac78690f3df92f6dd6f59754c750110bca66d64e/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c", size = 45698566 },
-    { url = "https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041", size = 48835562 },
-    { url = "https://files.pythonhosted.org/packages/a5/63/097510448e47e4091faa41c43ba92f97cecaab8f4535b56a3d149578f634/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491", size = 49394997 },
-    { url = "https://files.pythonhosted.org/packages/60/6b/c047d6222ab279024a062742d1807e2fbaf27bba88a98637299ff47b9236/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1", size = 51911424 },
-    { url = "https://files.pythonhosted.org/packages/3a/ba/464cc70761c2a525d97ebd84e21c31ebd47f3ef4bdcee117009f51c46f24/pyarrow-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:c42ab9439498270139cc63e18847a02afe5c8b3ed9c931266533cfe378bd3591", size = 27251730 },
-    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898 },
-    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915 },
-    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931 },
-    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449 },
-    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949 },
-    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986 },
-    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371 },
-    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559 },
-    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654 },
-    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394 },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122 },
-    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032 },
-    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490 },
-    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660 },
-    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759 },
-    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471 },
-    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981 },
-    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172 },
-    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733 },
-    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335 },
-    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748 },
-    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554 },
-    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301 },
-    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929 },
-    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365 },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819 },
-    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252 },
-    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127 },
-    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997 },
-    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720 },
-    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852 },
-    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852 },
-    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207 },
-    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117 },
-    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155 },
-    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387 },
-    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102 },
-    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118 },
-    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765 },
-    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890 },
-    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250 },
-    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282 },
+    { url = "https://files.pythonhosted.org/packages/bc/a8/24e5dc6855f50a62936ceb004e6e9645e4219a8065f304145d7fb8a79d5d/pyarrow-23.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3fab8f82571844eb3c460f90a75583801d14ca0cc32b1acc8c361650e006fd56", size = 34307390 },
+    { url = "https://files.pythonhosted.org/packages/bc/8e/4be5617b4aaae0287f621ad31c6036e5f63118cfca0dc57d42121ff49b51/pyarrow-23.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3f91c038b95f71ddfc865f11d5876c42f343b4495535bd262c7b321b0b94507c", size = 35853761 },
+    { url = "https://files.pythonhosted.org/packages/2e/08/3e56a18819462210432ae37d10f5c8eed3828be1d6c751b6e6a2e93c286a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d0744403adabef53c985a7f8a082b502a368510c40d184df349a0a8754533258", size = 44493116 },
+    { url = "https://files.pythonhosted.org/packages/f8/82/c40b68001dbec8a3faa4c08cd8c200798ac732d2854537c5449dc859f55a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c33b5bf406284fd0bba436ed6f6c3ebe8e311722b441d89397c54f871c6863a2", size = 47564532 },
+    { url = "https://files.pythonhosted.org/packages/20/bc/73f611989116b6f53347581b02177f9f620efdf3cd3f405d0e83cdf53a83/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ddf743e82f69dcd6dbbcb63628895d7161e04e56794ef80550ac6f3315eeb1d5", size = 48183685 },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/6c6b3ecdae2a8c3aced99956187e8302fc954cc2cca2a37cf2111dad16ce/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e052a211c5ac9848ae15d5ec875ed0943c0221e2fcfe69eee80b604b4e703222", size = 50605582 },
+    { url = "https://files.pythonhosted.org/packages/8d/94/d359e708672878d7638a04a0448edf7c707f9e5606cee11e15aaa5c7535a/pyarrow-23.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:5abde149bb3ce524782d838eb67ac095cd3fd6090eba051130589793f1a7f76d", size = 27521148 },
+    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230 },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050 },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918 },
+    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811 },
+    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766 },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669 },
+    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698 },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575 },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540 },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940 },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063 },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045 },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741 },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678 },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066 },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526 },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279 },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798 },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446 },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972 },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749 },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544 },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911 },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337 },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944 },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269 },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794 },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642 },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755 },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826 },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859 },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443 },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991 },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077 },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271 },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692 },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383 },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119 },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199 },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435 },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149 },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807 },
 ]
 
 [[package]]
@@ -3564,15 +3570,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/0d/2a/b6c793a17e173524c
 
 [[package]]
 name = "pystow"
-version = "0.8.5"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/62/c8db12b9ad4b1290c5e9a9f00ac6f53a0019067e37972bd06785a2259230/pystow-0.8.5.tar.gz", hash = "sha256:c918ead173ed5d0234a888e3d480e00d3fe3ee608c9fc0722796d72aa4e44438", size = 51845 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/bb/6c9009123d31dfeaad9dd71735ccaeeac31e01f7a12b260e8596238b2aa2/pystow-0.8.4.tar.gz", hash = "sha256:6dd2ee27c9214389c0ccf6ed35e671af9b562b8cf48702e1d26f1011c3dce72a", size = 51696 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/2c/a7e83774a42af984645cbdc27320fcd6c3f2d3af5508b20b1a0924900e12/pystow-0.8.5-py3-none-any.whl", hash = "sha256:a8593a22ec6a16c39ee0458b393db30abbba1e9f95f2865c5793df7e81c51e9e", size = 58857 },
+    { url = "https://files.pythonhosted.org/packages/15/29/169b1824fa3d45e2d5630cd53e87f3f89fda68b5be6a7c7c06ffac940f8e/pystow-0.8.4-py3-none-any.whl", hash = "sha256:ee9536d189eccd2398525b179b47dd51bed576752c8ecb80260f39572a82dc18", size = 58715 },
 ]
 
 [[package]]
@@ -4490,6 +4496,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #8.

`BiosampleToParquetJob` wires together MongoSource (#4) → SchemaDrivenFlattener (#13) → ParquetSink (#7) and registers as `"biosamples-to-parquet"` via Sierra's `@register` decorator. Run with:

```
nmdc-lakehouse run-job biosamples-to-parquet
```

Arrow schema is derived from `nmdc-schema` at run time (via #12's `flatten_class_def`) so column types are stable across all batched writes. Lazy imports decouple this module from the other feature branches until they merge.

Unit tests cover registration and registry roundtrip. Integration tests (dry-run + full write) are marked `@pytest.mark.integration` and run against `nmdc_lakehouse_prep` when `ENABLE_DB_TESTS=true`.