### PR TITLE
Add local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 /tmp/
 /output/
 /lakehouse/
+/local/
 *.parquet
 *.iceberg/
 reports/


### PR DESCRIPTION
`local/` holds ETL log files and run artifacts that should never be tracked. Was missing from `.gitignore`.