### PR TITLE
Ignore lakehouse_backup*/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 /tmp/
 /output/
 /lakehouse/
+/lakehouse_backup*/
 /local/
 *.parquet
 *.iceberg/


### PR DESCRIPTION
Covers timestamped backup directories created before re-running ETL jobs.