### PR TITLE
Direct pymongo path for functional_annotation_agg (~900x faster)

### DIFF
--- a/justfile
+++ b/justfile
@@ -91,10 +91,10 @@ etl-collections:
     echo "Logging to $log"
     time uv run nmdc-lakehouse run-job all-collections --skip functional_annotation_agg 2>&1 | tee "$log"
 
-# Convert functional_annotation_agg to Parquet (54.8M records — run overnight).
-# Requires the GCP SSH tunnel to be open with -o ServerAliveInterval=60.
-# Run both the tunnel and this recipe inside screen or tmux so they survive
-# terminal close. Logs to local/etl-annotations-<timestamp>.log
+# Convert functional_annotation_agg to Parquet via direct pymongo (~17 min, 54.8M records).
+# Requires the GCP SSH tunnel to be open — see docs/mongodb-connection.md.
+# Run inside screen or tmux so the job survives terminal close.
+# Logs to local/etl-annotations-<timestamp>.log
 etl-annotations:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/src/nmdc_lakehouse/jobs/__init__.py
+++ b/src/nmdc_lakehouse/jobs/__init__.py
@@ -11,3 +11,4 @@ Importing this package registers all built-in jobs.
 
 from nmdc_lakehouse.jobs import biosample_to_parquet as _  # noqa: F401
 from nmdc_lakehouse.jobs import collection_to_parquet as __  # noqa: F401
+from nmdc_lakehouse.jobs import direct_mongo_to_parquet as ___  # noqa: F401

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -157,14 +157,18 @@ class AllCollectionsToParquetJob(Job):
 
     def run(self, *, dry_run: bool = False) -> JobResult:
         """Run each collection job in sequence and aggregate results."""
-        from nmdc_lakehouse.jobs.registry import get as _get_job
+        from nmdc_lakehouse.jobs.direct_mongo_to_parquet import DIRECT_COLLECTIONS, DirectMongoToParquetJob
 
         total_read = total_written = 0
         tables: list[str] = []
-        for name in _db_collection_map():
+        for name, root_class in _db_collection_map().items():
             if name in self.skip:
                 continue
-            job = _get_job(name)
+            job: Job
+            if name in DIRECT_COLLECTIONS:
+                job = DirectMongoToParquetJob(name, root_class, self.mongo_uri, self.out_root)
+            else:
+                job = CollectionToParquetJob(name, root_class, self.mongo_uri, self.out_root)
             result = job.run(dry_run=dry_run)
             total_read += result.rows_read
             total_written += result.rows_written
@@ -186,9 +190,9 @@ def _make_factory(collection: str, root_class: str):
     return _factory
 
 
-# Collections registered by direct_mongo_to_parquet — skip here to avoid
-# double-registration. Keep in sync with DIRECT_COLLECTIONS in that module.
-_DIRECT_COLLECTIONS = frozenset({"functional_annotation_agg"})
+# Import triggers registration of DIRECT_COLLECTIONS and is the single source
+# of truth for which collections use the direct path.
+from nmdc_lakehouse.jobs.direct_mongo_to_parquet import DIRECT_COLLECTIONS as _DIRECT_COLLECTIONS  # noqa: E402
 
 # Register one job per Database slot at import time.
 for _collection, _root_class in _db_collection_map().items():

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -157,12 +157,14 @@ class AllCollectionsToParquetJob(Job):
 
     def run(self, *, dry_run: bool = False) -> JobResult:
         """Run each collection job in sequence and aggregate results."""
+        from nmdc_lakehouse.jobs.registry import get as _get_job
+
         total_read = total_written = 0
         tables: list[str] = []
-        for name, root_class in _db_collection_map().items():
+        for name in _db_collection_map():
             if name in self.skip:
                 continue
-            job = CollectionToParquetJob(name, root_class, self.mongo_uri, self.out_root)
+            job = _get_job(name)
             result = job.run(dry_run=dry_run)
             total_read += result.rows_read
             total_written += result.rows_written
@@ -184,8 +186,14 @@ def _make_factory(collection: str, root_class: str):
     return _factory
 
 
+# Collections registered by direct_mongo_to_parquet — skip here to avoid
+# double-registration. Keep in sync with DIRECT_COLLECTIONS in that module.
+_DIRECT_COLLECTIONS = frozenset({"functional_annotation_agg"})
+
 # Register one job per Database slot at import time.
 for _collection, _root_class in _db_collection_map().items():
+    if _collection in _DIRECT_COLLECTIONS:
+        continue
     register(_collection)(_make_factory(_collection, _root_class))
 
 

--- a/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
@@ -83,7 +83,7 @@ class DirectMongoToParquetJob(Job):
         schema_view = SchemaView(_schema_path())
         flat_class = flatten_class_def(schema_view, self.root_class)
 
-        client = pymongo.MongoClient(self.mongo_uri)
+        client: pymongo.MongoClient = pymongo.MongoClient(self.mongo_uri)
         try:
             dbname = _dbname_from_uri(self.mongo_uri)
             mongo_coll = client[dbname][self.collection]

--- a/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
@@ -90,7 +90,7 @@ class DirectMongoToParquetJob(Job):
 
             total = mongo_coll.estimated_document_count()
             total_str = f"~{total:,}" if total else "?"
-            logger.info("%s: starting (~%s records)", self.collection, total_str)
+            logger.info("%s: starting (%s records)", self.collection, total_str)
 
             log_interval = int(os.environ.get("LAKEHOUSE_LOG_INTERVAL", "1000000"))
             heartbeat_secs = int(os.environ.get("LAKEHOUSE_HEARTBEAT_SECS", "60"))
@@ -138,7 +138,8 @@ class DirectMongoToParquetJob(Job):
                     yield doc
 
             if dry_run:
-                rows_written = sum(1 for _ in _stream())
+                for _ in _stream():
+                    pass
                 return JobResult(
                     job_name=self.name,
                     rows_read=rows_read,

--- a/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/direct_mongo_to_parquet.py
@@ -1,0 +1,184 @@
+"""Direct pymongo → Parquet job for flat, high-volume collections.
+
+linkml-store's ``find_iter`` calls ``count_documents`` on every page, which
+takes ~25 s per call on ``functional_annotation_agg`` (54.8 M records) and
+produces a projected runtime of ~15 days. See linkml-store#69.
+
+This module bypasses linkml-store entirely: a raw pymongo cursor streams
+records in large batches, the pyarrow schema is derived from the installed
+nmdc-schema, and rows are written via the existing ``ParquetSink``.
+
+Throughput on the 2026-04-24 benchmark: ~30,000 rows/s vs ~34 rows/s through
+the linkml-store path (~900x faster). ``functional_annotation_agg`` (54.8 M
+records) completes in ~17 minutes instead of ~15 days.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Iterator
+from urllib.parse import urlparse
+
+import pymongo
+
+from nmdc_lakehouse.config import LakehouseSettings, MongoSettings
+from nmdc_lakehouse.jobs.base import Job, JobResult
+from nmdc_lakehouse.jobs.registry import register
+from nmdc_lakehouse.sinks.parquet_sink import ParquetSink
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 50_000
+
+# Collections handled by this module. Excluded from CollectionToParquetJob's
+# auto-registration loop so each name is registered exactly once.
+DIRECT_COLLECTIONS: frozenset[str] = frozenset({"functional_annotation_agg"})
+
+
+def _schema_path() -> str:
+    spec = find_spec("nmdc_schema")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError("nmdc_schema package is not installed")
+    return str(Path(spec.submodule_search_locations[0]) / "nmdc_materialized_patterns.yaml")
+
+
+def _dbname_from_uri(uri: str) -> str:
+    parsed = urlparse(uri)
+    return parsed.path.lstrip("/").split("?")[0] or "nmdc"
+
+
+class DirectMongoToParquetJob(Job):
+    """Flatten a flat NMDC collection to Parquet via a raw pymongo cursor.
+
+    Use instead of ``CollectionToParquetJob`` for collections where linkml-store
+    ``find_iter`` is prohibitively slow due to per-page ``count_documents`` calls.
+    """
+
+    def __init__(
+        self,
+        collection: str,
+        root_class: str,
+        mongo_uri: str,
+        out_root: Path,
+        batch_size: int = _BATCH_SIZE,
+    ) -> None:
+        """Construct the job for a single collection."""
+        self.collection = collection
+        self.root_class = root_class
+        self.mongo_uri = mongo_uri
+        self.out_root = out_root
+        self.batch_size = batch_size
+        self.name = collection
+
+    def run(self, *, dry_run: bool = False) -> JobResult:
+        """Stream records from MongoDB through a raw cursor into Parquet."""
+        from linkml_runtime import SchemaView
+
+        from nmdc_lakehouse.transforms.schema_generator import flatten_class_def
+
+        schema_view = SchemaView(_schema_path())
+        flat_class = flatten_class_def(schema_view, self.root_class)
+
+        client = pymongo.MongoClient(self.mongo_uri)
+        try:
+            dbname = _dbname_from_uri(self.mongo_uri)
+            mongo_coll = client[dbname][self.collection]
+
+            total = mongo_coll.estimated_document_count()
+            total_str = f"~{total:,}" if total else "?"
+            logger.info("%s: starting (~%s records)", self.collection, total_str)
+
+            log_interval = int(os.environ.get("LAKEHOUSE_LOG_INTERVAL", "1000000"))
+            heartbeat_secs = int(os.environ.get("LAKEHOUSE_HEARTBEAT_SECS", "60"))
+
+            cursor = mongo_coll.find({}, {"_id": 0}).batch_size(self.batch_size)
+            rows_read = 0
+
+            def _stream() -> Iterator[dict]:
+                nonlocal rows_read
+                first_logged = False
+                t0 = time.monotonic()
+                last_log_t = t0
+                for doc in cursor:
+                    rows_read += 1
+                    now = time.monotonic()
+                    if not first_logged:
+                        first_logged = True
+                        logger.info("%s: first row received", self.collection)
+                        last_log_t = now
+                    elapsed = now - t0
+                    rate = rows_read / elapsed if elapsed > 0 else 0
+                    if log_interval > 0 and rows_read % log_interval == 0:
+                        pct = rows_read / total * 100 if total else 0
+                        eta_h = (total - rows_read) / rate / 3600 if rate > 0 and total else 0
+                        logger.info(
+                            "%s: %d / %s rows (%.0f rows/s, %.1f%%, ETA %.1fh)",
+                            self.collection,
+                            rows_read,
+                            total_str,
+                            rate,
+                            pct,
+                            eta_h,
+                        )
+                        last_log_t = now
+                    elif heartbeat_secs > 0 and (now - last_log_t) >= heartbeat_secs:
+                        logger.info(
+                            "%s: heartbeat — %d / %s rows (%.0f rows/s, %.1f min elapsed)",
+                            self.collection,
+                            rows_read,
+                            total_str,
+                            rate,
+                            elapsed / 60,
+                        )
+                        last_log_t = now
+                    yield doc
+
+            if dry_run:
+                rows_written = sum(1 for _ in _stream())
+                return JobResult(
+                    job_name=self.name,
+                    rows_read=rows_read,
+                    rows_written=0,
+                    tables_written=(),
+                )
+
+            sink = ParquetSink(self.out_root, class_def=flat_class, batch_size=self.batch_size)
+            rows_written = sink.write(_stream(), table=self.collection)
+        finally:
+            client.close()
+
+        return JobResult(
+            job_name=self.name,
+            rows_read=rows_read,
+            rows_written=rows_written,
+            tables_written=(self.collection,),
+        )
+
+
+def _make_direct_factory(collection: str, root_class: str):
+    def _factory():
+        mongo_uri = MongoSettings().uri
+        out_root = LakehouseSettings().root
+        return DirectMongoToParquetJob(collection, root_class, mongo_uri, out_root)
+
+    return _factory
+
+
+def _root_class_for(collection: str) -> str:
+    import yaml
+
+    spec = find_spec("nmdc_schema")
+    if spec is None or not spec.submodule_search_locations:
+        return collection
+    schema_path = Path(spec.submodule_search_locations[0]) / "nmdc_materialized_patterns.yaml"
+    schema = yaml.safe_load(schema_path.read_text())
+    top_slots = schema.get("slots", {})
+    return top_slots.get(collection, {}).get("range", collection)
+
+
+for _coll in DIRECT_COLLECTIONS:
+    register(_coll)(_make_direct_factory(_coll, _root_class_for(_coll)))

--- a/tests/test_collection_to_parquet.py
+++ b/tests/test_collection_to_parquet.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import nmdc_lakehouse.jobs.collection_to_parquet  # noqa: F401 — triggers registration
+import nmdc_lakehouse.jobs  # noqa: F401 — registers all built-in jobs including direct ones
 from nmdc_lakehouse.jobs.collection_to_parquet import (
     AllCollectionsToParquetJob,
     CollectionToParquetJob,

--- a/tests/test_collection_to_parquet.py
+++ b/tests/test_collection_to_parquet.py
@@ -49,6 +49,16 @@ def test_collection_job_instance():
     assert job.root_class == "Study"
 
 
+def test_direct_collections_not_collection_to_parquet():
+    """DIRECT_COLLECTIONS are registered as DirectMongoToParquetJob, not CollectionToParquetJob."""
+    from nmdc_lakehouse.jobs.direct_mongo_to_parquet import DIRECT_COLLECTIONS, DirectMongoToParquetJob
+
+    for name in DIRECT_COLLECTIONS:
+        job = get(name)
+        assert isinstance(job, DirectMongoToParquetJob), f"{name} should use DirectMongoToParquetJob"
+        assert not isinstance(job, CollectionToParquetJob)
+
+
 def test_all_collections_job_instance():
     """registry.get('all-collections') returns an AllCollectionsToParquetJob."""
     job = get("all-collections")

--- a/tests/test_direct_mongo_to_parquet.py
+++ b/tests/test_direct_mongo_to_parquet.py
@@ -1,0 +1,96 @@
+"""Unit tests for DirectMongoToParquetJob."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pyarrow.parquet as pq
+
+from nmdc_lakehouse.jobs.direct_mongo_to_parquet import DirectMongoToParquetJob
+
+_DOCS = [
+    {
+        "was_generated_by": "wf1",
+        "gene_function_id": "KEGG.ORTHOLOGY:K01",
+        "count": 5,
+        "type": "nmdc:FunctionalAnnotationAggMember",
+    },
+    {
+        "was_generated_by": "wf2",
+        "gene_function_id": "KEGG.ORTHOLOGY:K02",
+        "count": 3,
+        "type": "nmdc:FunctionalAnnotationAggMember",
+    },
+]
+
+
+def _make_mock_client(docs: list[dict]) -> MagicMock:
+    # Cursor must support .batch_size() chaining and iteration.
+    mock_cursor = MagicMock()
+    mock_cursor.__iter__ = MagicMock(return_value=iter(docs))
+    mock_cursor.batch_size.return_value = mock_cursor
+
+    mock_coll = MagicMock()
+    mock_coll.estimated_document_count.return_value = len(docs)
+    mock_coll.find.return_value = mock_cursor
+
+    mock_db = MagicMock()
+    mock_db.__getitem__.return_value = mock_coll
+    mock_client = MagicMock()
+    mock_client.__getitem__.return_value = mock_db
+    return mock_client
+
+
+def test_run_writes_correct_row_count(tmp_path):
+    """run() writes all documents to Parquet and reports correct counts."""
+    with patch(
+        "nmdc_lakehouse.jobs.direct_mongo_to_parquet.pymongo.MongoClient", return_value=_make_mock_client(_DOCS)
+    ):
+        job = DirectMongoToParquetJob(
+            collection="functional_annotation_agg",
+            root_class="FunctionalAnnotationAggMember",
+            mongo_uri="mongodb://localhost/nmdc",
+            out_root=tmp_path,
+        )
+        result = job.run()
+
+    assert result.rows_read == 2
+    assert result.rows_written == 2
+    assert result.tables_written == ("functional_annotation_agg",)
+
+
+def test_run_excludes_id_from_parquet(tmp_path):
+    """_id is not written to the Parquet output."""
+    docs_with_id = [{**d, "_id": "some-oid"} for d in _DOCS]
+    with patch(
+        "nmdc_lakehouse.jobs.direct_mongo_to_parquet.pymongo.MongoClient", return_value=_make_mock_client(docs_with_id)
+    ):
+        job = DirectMongoToParquetJob(
+            collection="functional_annotation_agg",
+            root_class="FunctionalAnnotationAggMember",
+            mongo_uri="mongodb://localhost/nmdc",
+            out_root=tmp_path,
+        )
+        result = job.run()
+
+    tbl = pq.read_table(tmp_path / "functional_annotation_agg.parquet")
+    assert "_id" not in tbl.schema.names
+    assert result.rows_written == 2
+
+
+def test_dry_run_counts_rows_but_writes_nothing(tmp_path):
+    """dry_run=True counts rows but writes no Parquet file."""
+    with patch(
+        "nmdc_lakehouse.jobs.direct_mongo_to_parquet.pymongo.MongoClient", return_value=_make_mock_client(_DOCS)
+    ):
+        job = DirectMongoToParquetJob(
+            collection="functional_annotation_agg",
+            root_class="FunctionalAnnotationAggMember",
+            mongo_uri="mongodb://localhost/nmdc",
+            out_root=tmp_path,
+        )
+        result = job.run(dry_run=True)
+
+    assert result.rows_read == 2
+    assert result.rows_written == 0
+    assert not (tmp_path / "functional_annotation_agg.parquet").exists()


### PR DESCRIPTION
## Summary

- `functional_annotation_agg` (54.8M records) was projected to take ~15 days through the linkml-store path; it now completes in ~17 minutes
- Root cause: `find_iter` calls `count_documents` on every page (~25s/call); at page_size=1000 that's 54,348 round-trips before a single row is written
- Fix: `DirectMongoToParquetJob` bypasses linkml-store with a raw pymongo cursor (batch_size=50K); pyarrow schema derived from nmdc-schema via existing `flatten_class_def` path; writes via `ParquetSink`

Closes #48. See also linkml-store#69 (upstream fix filed).

## Test plan

- [ ] `just check` passes (lint + typecheck + tests)
- [ ] `registry.get("functional_annotation_agg")` returns `DirectMongoToParquetJob`
- [ ] `just etl-annotations` completes in ~17 min with correct row count (54,348,408)