### PR TITLE
Emit normalized side tables for all multivalued slots

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,11 +75,9 @@ Simple lists of primitive values (`alternative_identifiers`, `analysis_type`,
 **pipe-joined into a single string column** (`"a|b|c"`). A side table (junction
 table with `parent_id` + value) is also generated for any slot that has data.
 
-**Open question:** The pipe-joined column and the junction table are redundant.
-The current default emits both. A `LAKEHOUSE_SCALAR_MV_MODE` env var is planned
-to let callers choose `concatenate` (primary table only, no scalar side tables —
-reduces 148 → 78 side tables), `tables` (both), or `split` (junction table only,
-drop the pipe-joined column from the primary table).
+The pipe-joined column and the junction table are redundant. See issue #60 for
+the planned replacement: native Parquet ARRAY columns, which eliminate both the
+pipe-join and the scalar side tables.
 
 ### Ref-class multivalued slots
 Lists of references to other NMDC objects (`associated_studies`, `has_input`,
@@ -88,17 +86,48 @@ are pipe-joined in the primary flat table **and** emitted as junction side table
 (`parent_id` + foreign key string). The side table is the correct relational form
 for joins; the pipe-joined column is a convenience for simple string searches.
 
+Native ARRAY columns (issue #60) would also replace these: `array_contains()` and
+`UNNEST` are supported in DuckDB, Spark, and Dremio, making junction side tables
+redundant at NMDC's data scale.
+
 ### Inlined multivalued slots
 Lists of embedded objects (`mags_list`, `chem_administration`, `organism_count`,
 `agrochem_addition`, etc.). These cannot be represented in the primary flat table
 without data loss. Each becomes a **child side table** (flattened object rows with
 `parent_id`). There is no redundancy — the side table is the only representation.
 
+### Recursive side tables
+Six cases in the current NMDC schema have inlined child classes that themselves
+contain multivalued slots, creating a need for grandchild tables:
+
+| Parent side table | Child class | Child multivalued slot |
+|---|---|---|
+| `workflow_execution_set_mags_list` | `MagBin` | `members_id` |
+| `study_set_has_credit_associations` | `CreditAssociation` | `applied_roles` |
+| `workflow_execution_set_has_metabolite_identifications` | `MetaboliteIdentification` | `alternative_identifiers` |
+| `configuration_set_ordered_mobile_phases` | `MobilePhaseSegment` | `substances_used` |
+| `material_processing_set_ordered_mobile_phases` | `MobilePhaseSegment` | `substances_used` |
+| `study_set_protocol_link` | `Protocol` | `analysis_type` |
+
+Currently these child multivalued slots are pipe-joined inside the side table row.
+With native ARRAY columns (issue #60), they would become ARRAY columns within the
+side table — eliminating the need for recursive side table generation entirely.
+
 ### Side table naming
 All side tables follow the pattern `{collection}_{slot_name}`, e.g.
 `biosample_set_associated_studies`, `workflow_execution_set_mags_list`.
 Only slots that have at least one populated record are written; empty side
 tables are silently skipped at runtime.
+
+### Query engine compatibility
+All target systems support Parquet native ARRAY types:
+
+| System | ARRAY support | Unnest syntax |
+|---|---|---|
+| DuckDB | ✅ native | `UNNEST()`, `array_contains()` |
+| Spark / Delta (BERDL) | ✅ native | `EXPLODE()`, `array_contains()` |
+| Dremio (JGI) | ✅ native | `FLATTEN()` |
+| Parquet (file format) | ✅ `pa.list_()` | — |
 
 ## Jobs and the runner (`nmdc_lakehouse.jobs`, `nmdc_lakehouse.cli`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,24 +71,17 @@ each handled differently:
 
 ### Scalar multivalued slots
 Simple lists of primitive values (`alternative_identifiers`, `analysis_type`,
-`funding_sources`, `tillage`, etc.). In the primary flat table these are
-**pipe-joined into a single string column** (`"a|b|c"`). A side table (junction
-table with `parent_id` + value) is also generated for any slot that has data.
-
-The pipe-joined column and the junction table are redundant. See issue #60 for
-the planned replacement: native Parquet ARRAY columns, which eliminate both the
-pipe-join and the scalar side tables.
+`funding_sources`, `tillage`, etc.). In the primary flat table these are stored as
+**native Parquet ARRAY columns** (`pa.list_(element_type)`). No scalar junction
+side table is generated.
 
 ### Ref-class multivalued slots
 Lists of references to other NMDC objects (`associated_studies`, `has_input`,
 `has_output`, `instrument_used`, etc.). These are true M:M relationships. They
-are pipe-joined in the primary flat table **and** emitted as junction side tables
-(`parent_id` + foreign key string). The side table is the correct relational form
-for joins; the pipe-joined column is a convenience for simple string searches.
-
-Native ARRAY columns (issue #60) would also replace these: `array_contains()` and
-`UNNEST` are supported in DuckDB, Spark, and Dremio, making junction side tables
-redundant at NMDC's data scale.
+are stored as **native ARRAY columns** in the primary flat table and **also**
+emitted as junction side tables (`parent_id` + foreign-key string). The side
+table is the correct relational form for joins; the ARRAY column supports simple
+`array_contains()` lookups without a join.
 
 ### Inlined multivalued slots
 Lists of embedded objects (`mags_list`, `chem_administration`, `organism_count`,
@@ -98,9 +91,10 @@ without data loss. Each becomes a **child side table** (flattened object rows wi
 
 ### Recursive side tables
 Six cases in the current NMDC schema have inlined child classes that themselves
-contain multivalued slots, creating a need for grandchild tables:
+contain multivalued slots. Those child slots are stored as ARRAY columns inside
+the side table row (same rule as the primary table):
 
-| Parent side table | Child class | Child multivalued slot |
+| Parent side table | Child class | Child ARRAY column |
 |---|---|---|
 | `workflow_execution_set_mags_list` | `MagBin` | `members_id` |
 | `study_set_has_credit_associations` | `CreditAssociation` | `applied_roles` |
@@ -108,10 +102,6 @@ contain multivalued slots, creating a need for grandchild tables:
 | `configuration_set_ordered_mobile_phases` | `MobilePhaseSegment` | `substances_used` |
 | `material_processing_set_ordered_mobile_phases` | `MobilePhaseSegment` | `substances_used` |
 | `study_set_protocol_link` | `Protocol` | `analysis_type` |
-
-Currently these child multivalued slots are pipe-joined inside the side table row.
-With native ARRAY columns (issue #60), they would become ARRAY columns within the
-side table — eliminating the need for recursive side table generation entirely.
 
 ### Side table naming
 All side tables follow the pattern `{collection}_{slot_name}`, e.g.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,32 @@ Genomic sequences and other bulk payloads are **not** inlined. They are
 represented by `BigDataRef` records (URI, size, checksum, media type)
 that live alongside the flattened metadata rows.
 
+## Data taxonomy — what this pipeline covers
+
+NMDC data falls into four categories with different loading strategies:
+
+**MongoDB metadata** (scope of this pipeline)
+The 17 schema-specified collections (`biosample_set`, `study_set`, `data_generation_set`, etc.)
+stored in the NMDC MongoDB instance. These are schema-validated, authoritative, and bounded
+in size (largest is `functional_annotation_agg` at ~54M rows). `nmdc-lakehouse` owns this
+path: MongoDB → Parquet → BERDL Silver.
+
+**Derived aggregates** (gray zone — already loaded, but not ground truth)
+`functional_annotation_agg` lives in MongoDB but is a pre-aggregated summary of GFF file
+content. It is a query convenience layer. The per-gene detail lives in NERSC files; the
+aggregate is one row per (workflow run, function term). Loading it via this pipeline is
+correct, but users should know it is not the source of record.
+
+**Workflow output files** (out of scope for this pipeline today)
+NERSC files under `/global/cfs/cdirs/m3408/gsharing/`: GFF annotations, GTDB-tk TSVs,
+CheckM TSVs, FAA sequences, MAG bin ZIPs, etc. These are referenced by `data_object_set`
+URLs but not loaded by this pipeline. A separate loading mechanism is needed (see issue #57).
+`data_object_set` records act as the index/manifest for these files.
+
+**Reference data** (out of scope — lives in other tenants)
+KEGG, COG, GTDB taxonomy reference tables. Currently in `nmdc_arkin` (Gazi's tenant) with
+no refresh path. Not part of the NMDC data model; not owned by this pipeline.
+
 ## Jobs and the runner (`nmdc_lakehouse.jobs`, `nmdc_lakehouse.cli`)
 
 A `Job` composes a source, zero or more transforms, and a sink. Jobs are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,42 @@ URLs but not loaded by this pipeline. A separate loading mechanism is needed (se
 KEGG, COG, GTDB taxonomy reference tables. Currently in `nmdc_arkin` (Gazi's tenant) with
 no refresh path. Not part of the NMDC data model; not owned by this pipeline.
 
+## Normalization decisions — primary tables vs side tables
+
+Every multivalued slot in the NMDC schema falls into one of three categories,
+each handled differently:
+
+### Scalar multivalued slots
+Simple lists of primitive values (`alternative_identifiers`, `analysis_type`,
+`funding_sources`, `tillage`, etc.). In the primary flat table these are
+**pipe-joined into a single string column** (`"a|b|c"`). A side table (junction
+table with `parent_id` + value) is also generated for any slot that has data.
+
+**Open question:** The pipe-joined column and the junction table are redundant.
+The current default emits both. A `LAKEHOUSE_SCALAR_MV_MODE` env var is planned
+to let callers choose `concatenate` (primary table only, no scalar side tables —
+reduces 148 → 78 side tables), `tables` (both), or `split` (junction table only,
+drop the pipe-joined column from the primary table).
+
+### Ref-class multivalued slots
+Lists of references to other NMDC objects (`associated_studies`, `has_input`,
+`has_output`, `instrument_used`, etc.). These are true M:M relationships. They
+are pipe-joined in the primary flat table **and** emitted as junction side tables
+(`parent_id` + foreign key string). The side table is the correct relational form
+for joins; the pipe-joined column is a convenience for simple string searches.
+
+### Inlined multivalued slots
+Lists of embedded objects (`mags_list`, `chem_administration`, `organism_count`,
+`agrochem_addition`, etc.). These cannot be represented in the primary flat table
+without data loss. Each becomes a **child side table** (flattened object rows with
+`parent_id`). There is no redundancy — the side table is the only representation.
+
+### Side table naming
+All side tables follow the pattern `{collection}_{slot_name}`, e.g.
+`biosample_set_associated_studies`, `workflow_execution_set_mags_list`.
+Only slots that have at least one populated record are written; empty side
+tables are silently skipped at runtime.
+
 ## Jobs and the runner (`nmdc_lakehouse.jobs`, `nmdc_lakehouse.cli`)
 
 A `Job` composes a source, zero or more transforms, and a sink. Jobs are

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -61,12 +61,22 @@ class CollectionToParquetJob(Job):
         self.name = collection
 
     def run(self, *, dry_run: bool = False) -> JobResult:
-        """Stream records from MongoDB through the flattener into Parquet."""
+        """Stream records from MongoDB through the flattener into Parquet.
+
+        Side tables (for all multivalued slots) are buffered in memory during
+        the primary stream and written after the primary table is complete.
+        All collections processed by this job are small enough that buffering
+        is safe; ``functional_annotation_agg`` uses ``DirectMongoToParquetJob``.
+        """
         from importlib.util import find_spec
 
         from linkml_runtime import SchemaView
 
-        from nmdc_lakehouse.transforms.schema_generator import flatten_class_def
+        from nmdc_lakehouse.transforms.flatteners import side_table_rows
+        from nmdc_lakehouse.transforms.schema_generator import (
+            flatten_class_def,
+            side_table_class_defs,
+        )
 
         spec = find_spec("nmdc_schema")
         if spec is None or not spec.submodule_search_locations:
@@ -79,7 +89,16 @@ class CollectionToParquetJob(Job):
         flat_class = flatten_class_def(schema_view, self.root_class)
         sink = ParquetSink(self.out_root, class_def=flat_class)
 
-        records = source.iter_records(self.collection)
+        # Buffer for side table rows accumulated during the primary stream.
+        side_buffer: dict[str, list[dict]] = {}
+
+        def _tee_side_tables(raw_records):
+            for record in raw_records:
+                for table_name, row in side_table_rows(record, schema_view, self.root_class, self.collection):
+                    side_buffer.setdefault(table_name, []).append(row)
+                yield record
+
+        records = _tee_side_tables(source.iter_records(self.collection))
         flat_rows = flattener.apply(records)
 
         if dry_run:
@@ -130,11 +149,24 @@ class CollectionToParquetJob(Job):
                 yield row
 
         rows_written: int = sink.write(_counted(flat_rows), table=self.collection, drop_empty_cols=drop_empty) or 0
+
+        # Write side tables.
+        side_defs = dict(side_table_class_defs(schema_view, self.root_class, self.collection))
+        side_tables: list[str] = []
+        for table_name, side_rows in side_buffer.items():
+            if not side_rows:
+                continue
+            cd = side_defs.get(table_name)
+            side_sink = ParquetSink(self.out_root, class_def=cd)
+            n = side_sink.write(iter(side_rows), table=table_name) or 0
+            logger.info("%s: wrote %d rows to side table %s", self.collection, n, table_name)
+            side_tables.append(table_name)
+
         return JobResult(
             job_name=self.name,
             rows_read=rows_read,
             rows_written=rows_written,
-            tables_written=(self.collection,),
+            tables_written=(self.collection, *side_tables),
         )
 
 

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -65,8 +65,9 @@ class CollectionToParquetJob(Job):
 
         Side tables (for all multivalued slots) are buffered in memory during
         the primary stream and written after the primary table is complete.
-        All collections processed by this job are small enough that buffering
-        is safe; ``functional_annotation_agg`` uses ``DirectMongoToParquetJob``.
+        Memory usage scales with the total number of side-table rows, not the
+        number of primary records. ``functional_annotation_agg`` uses
+        ``DirectMongoToParquetJob`` because it is too large for this path.
         """
         from importlib.util import find_spec
 

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -129,18 +129,18 @@ class CollectionToParquetJob(Job):
                 rate = rows_read / elapsed if elapsed > 0 else 0
                 if log_interval > 0 and rows_read % log_interval == 0:
                     logger.info(
-                        "%s: %d / %s rows (%.0f rows/s)",
+                        "%s: %s / %s rows (%.0f rows/s)",
                         self.collection,
-                        rows_read,
+                        f"{rows_read:,}",
                         total_str,
                         rate,
                     )
                     last_log_t = now
                 elif heartbeat_secs > 0 and (now - last_log_t) >= heartbeat_secs:
                     logger.info(
-                        "%s: heartbeat — %d / %s rows (%.0f rows/s, %.1f min elapsed)",
+                        "%s: heartbeat — %s / %s rows (%.0f rows/s, %.1f min elapsed)",
                         self.collection,
-                        rows_read,
+                        f"{rows_read:,}",
                         total_str,
                         rate,
                         elapsed / 60,

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -63,8 +63,11 @@ class CollectionToParquetJob(Job):
     def run(self, *, dry_run: bool = False) -> JobResult:
         """Stream records from MongoDB through the flattener into Parquet.
 
-        Side tables (for all multivalued slots) are buffered in memory during
-        the primary stream and written after the primary table is complete.
+        Side tables (for ref-class and inlined-class multivalued slots) are
+        buffered in memory during the primary stream and written after the
+        primary table is complete. Scalar multivalued slots are stored as
+        native Parquet ARRAY columns in the primary table and do not produce
+        side tables.
         Memory usage scales with the total number of side-table rows, not the
         number of primary records. ``functional_annotation_agg`` uses
         ``DirectMongoToParquetJob`` because it is too large for this path.

--- a/src/nmdc_lakehouse/jobs/collection_to_parquet.py
+++ b/src/nmdc_lakehouse/jobs/collection_to_parquet.py
@@ -157,11 +157,15 @@ class CollectionToParquetJob(Job):
             if not side_rows:
                 continue
             cd = side_defs.get(table_name)
+            if cd is None:
+                logger.warning("%s: no ClassDef for side table %s — skipping", self.collection, table_name)
+                continue
             side_sink = ParquetSink(self.out_root, class_def=cd)
             n = side_sink.write(iter(side_rows), table=table_name) or 0
             logger.info("%s: wrote %d rows to side table %s", self.collection, n, table_name)
             side_tables.append(table_name)
 
+        side_tables.sort()
         return JobResult(
             job_name=self.name,
             rows_read=rows_read,

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -31,14 +31,15 @@ _RANGE_TO_ARROW: dict[str, pa.DataType] = {
 
 
 def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
-    """Derive a PyArrow schema from a (flat) LinkML ClassDefinition.
+    """Derive a PyArrow schema from a LinkML ClassDefinition.
 
-    Each attribute becomes a nullable Arrow field. The range is mapped
-    via ``_RANGE_TO_ARROW``; unknown ranges default to string.
+    Each attribute becomes a nullable Arrow field. The range is mapped via
+    ``_RANGE_TO_ARROW``; unknown ranges default to string. Multivalued slots
+    become ``pa.list_(element_type)``.
 
     Args:
-        class_def: A flat ``ClassDefinition`` whose attributes have scalar
-            ranges (as produced by :func:`nmdc_lakehouse.transforms.schema_generator.flatten_class_def`).
+        class_def: A ``ClassDefinition`` produced by
+            :func:`nmdc_lakehouse.transforms.schema_generator.flatten_class_def`.
 
     Returns:
         A ``pa.Schema`` with ``id`` first (if present), then remaining fields
@@ -52,7 +53,8 @@ def class_def_to_arrow_schema(class_def: ClassDefinition) -> pa.Schema:
     for name in names:
         slot = class_def.attributes[name]
         range_name = slot.range or "string"
-        arrow_type = _RANGE_TO_ARROW.get(range_name, pa.string())
+        element_type = _RANGE_TO_ARROW.get(range_name, pa.string())
+        arrow_type = pa.list_(element_type) if slot.multivalued else element_type
         fields.append(pa.field(name, arrow_type, nullable=True))
     return pa.schema(fields)
 
@@ -160,12 +162,16 @@ def _coerce(value: object, arrow_type: pa.DataType) -> object:
 
     Arrow is strict about types; real NMDC data sometimes has numeric values
     in slots declared as string (e.g. ``depth_has_raw_value = 0.5``). When
-    the value is incompatible with a string column, stringify it. For numeric
-    columns, leave None as-is and let Arrow handle coercion from compatible
-    Python scalars.
+    the value is incompatible with a string column, stringify it. For list
+    columns, wrap non-list values and recursively coerce elements.
     """
     if value is None:
         return None
+    if pa.types.is_list(arrow_type):
+        if not isinstance(value, list):
+            value = [value]
+        elem_type = arrow_type.value_type
+        return [_coerce(v, elem_type) for v in value]
     if arrow_type == pa.string() and not isinstance(value, str):
         return str(value)
     return value

--- a/src/nmdc_lakehouse/sinks/parquet_sink.py
+++ b/src/nmdc_lakehouse/sinks/parquet_sink.py
@@ -130,7 +130,7 @@ class ParquetSink:
 
         if drop_empty_cols and out_path.exists():
             tbl = pq.read_table(out_path)
-            non_empty = [name for name in tbl.schema.names if tbl.column(name).null_count < len(tbl)]
+            non_empty = [name for name in tbl.schema.names if _col_has_data(tbl.column(name))]
             if len(non_empty) < len(tbl.schema.names):
                 pq.write_table(tbl.select(non_empty), out_path)
 
@@ -155,6 +155,17 @@ class ParquetSink:
             ]
             return pa.table(dict(zip(self._arrow_schema.names, arrays, strict=True)), schema=self._arrow_schema)
         return pa.Table.from_pylist(rows)
+
+
+def _col_has_data(col: pa.ChunkedArray) -> bool:
+    """Return True if the column has at least one non-null, non-empty value.
+
+    For list columns a row whose value is [] has null_count==0 but carries no
+    data; flatten() returns an empty array in that case so the column is dropped.
+    """
+    if pa.types.is_list(col.type):
+        return len(col.combine_chunks().flatten()) > 0
+    return col.null_count < len(col)
 
 
 def _coerce(value: object, arrow_type: pa.DataType) -> object:

--- a/src/nmdc_lakehouse/transforms/flatteners.py
+++ b/src/nmdc_lakehouse/transforms/flatteners.py
@@ -227,6 +227,12 @@ def side_table_rows(
             table name prefix.
     """
     effective_class = _dispatch_class(record, root_class, schema_view)
+    # Constrain dispatch to root_class hierarchy; an out-of-hierarchy type
+    # would produce table names that have no ClassDef in side_table_class_defs.
+    if effective_class != root_class:
+        ancestors = schema_view.all_ancestors(effective_class, mixins=True) or []
+        if root_class not in ancestors:
+            effective_class = root_class
     parent_id = record.get("id", "")
 
     for slot in schema_view.class_induced_slots(effective_class):
@@ -255,7 +261,7 @@ def side_table_rows(
         else:
             for v in value:
                 if v is not None:
-                    yield table_name, {"parent_id": parent_id, slot.name: _stringify(v)}
+                    yield table_name, {"parent_id": parent_id, slot.name: v}
 
 
 class SchemaDrivenFlattener:

--- a/src/nmdc_lakehouse/transforms/flatteners.py
+++ b/src/nmdc_lakehouse/transforms/flatteners.py
@@ -200,6 +200,64 @@ def _stringify(value: Any) -> str:
     return str(value)
 
 
+def side_table_rows(
+    record: dict,
+    schema_view: SchemaView,
+    root_class: str,
+    collection: str,
+) -> Iterator[tuple[str, dict]]:
+    """Yield ``(table_name, row_dict)`` for every side table row from one record.
+
+    Three slot types produce side table rows:
+
+    - **scalar multivalued** — one ``(parent_id, <slot_name>)`` row per element.
+    - **ref_class multivalued** (class range, not inlined) — one
+      ``(parent_id, <slot_name>)`` row per referenced ID.
+    - **inlined_class multivalued** — one flattened child-object row per element,
+      with ``parent_id`` prepended.
+
+    ``table_name`` is ``{collection}_{slot_name}`` in all cases.
+
+    Args:
+        record: A dict representation of a ``root_class`` instance.
+        schema_view: Loaded LinkML SchemaView.
+        root_class: Declared class for ``record`` (polymorphic dispatch is
+            applied via the ``type`` field).
+        collection: Collection name (e.g. ``biosample_set``) — used as the
+            table name prefix.
+    """
+    effective_class = _dispatch_class(record, root_class, schema_view)
+    parent_id = record.get("id", "")
+
+    for slot in schema_view.class_induced_slots(effective_class):
+        if not slot.multivalued:
+            continue
+        if slot.name not in record:
+            continue
+        value = record[slot.name]
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            value = [value]
+        if not value:
+            continue
+
+        table_name = f"{collection}_{slot.name}"
+        range_class = _range_class(slot, schema_view)
+
+        if range_class is not None and _is_inlined(slot, schema_view):
+            for child in value:
+                if not isinstance(child, dict):
+                    continue
+                row = _expand_inlined(child, range_class, schema_view)
+                row["parent_id"] = parent_id
+                yield table_name, row
+        else:
+            for v in value:
+                if v is not None:
+                    yield table_name, {"parent_id": parent_id, slot.name: _stringify(v)}
+
+
 class SchemaDrivenFlattener:
     """Flatten NMDC objects using a LinkML SchemaView.
 

--- a/src/nmdc_lakehouse/transforms/flatteners.py
+++ b/src/nmdc_lakehouse/transforms/flatteners.py
@@ -230,7 +230,7 @@ def side_table_rows(
     # Constrain dispatch to root_class hierarchy; an out-of-hierarchy type
     # would produce table names that have no ClassDef in side_table_class_defs.
     if effective_class != root_class:
-        ancestors = schema_view.all_ancestors(effective_class, mixins=True) or []
+        ancestors = schema_view.class_ancestors(effective_class, mixins=True) or []
         if root_class not in ancestors:
             effective_class = root_class
     parent_id = record.get("id", "")

--- a/src/nmdc_lakehouse/transforms/flatteners.py
+++ b/src/nmdc_lakehouse/transforms/flatteners.py
@@ -7,25 +7,20 @@ from typing import Any, Iterable, Iterator
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 
-# Sentinel joining character for multivalued scalar slots. Matches the
-# convention used by external-metadata-awareness's flatten_nmdc_collections.py.
-LIST_JOIN = "|"
-
 
 def flatten_record(record: dict, schema_view: SchemaView, root_class: str) -> dict:
-    """Flatten a single nested record into a flat dict of scalar values.
+    """Flatten a single nested record into a flat dict.
 
     Decision tree, schema-driven (each slot of the effective class):
 
     - scalar slot, not multivalued: pass the value through unchanged
-    - scalar slot, multivalued: pipe-join the list into a string
+    - scalar slot, multivalued: emit a native Python list
     - class range, not inlined (reference by ID): treat the value(s) as
-      scalar identifiers — pass through or pipe-join like a scalar slot
+      scalar identifiers — pass through or emit as list
     - class range, inlined, not multivalued: expand the nested object's
       scalar slots as ``<slot>_<subslot>`` columns (one level deep)
-    - class range, inlined, multivalued: SKIPPED in this pass (helper
-      tables are a follow-up; main-row columns would be either ambiguous
-      or lossy)
+    - class range, inlined, multivalued: SKIPPED in this pass (child
+      side tables capture these rows)
 
     Polymorphism: when a record has a ``type`` field naming a subclass of
     ``root_class`` (or of an inlined slot's declared range), the concrete
@@ -46,7 +41,7 @@ def flatten_record(record: dict, schema_view: SchemaView, root_class: str) -> di
 
     Returns:
         A flat dict. Keys are slot names (or ``<slot>_<subslot>`` for
-        expanded inlined objects). Values are scalars or pipe-joined strings.
+        expanded inlined objects). Multivalued slots are Python lists.
     """
     out: dict[str, Any] = {}
     effective_class = _dispatch_class(record, root_class, schema_view)
@@ -60,24 +55,18 @@ def flatten_record(record: dict, schema_view: SchemaView, root_class: str) -> di
 
         range_class = _range_class(slot, schema_view)
 
-        # Class ranges that aren't inlined are references — treat as scalars.
+        # Class ranges that aren't inlined are references — IDs as scalars or lists.
         if range_class is not None and not _is_inlined(slot, schema_view):
-            if slot.multivalued:
-                if not isinstance(value, list):
-                    value = [value]
-                out[slot.name] = LIST_JOIN.join(_stringify(v) for v in value)
-            else:
-                out[slot.name] = value
+            if slot.multivalued and not isinstance(value, list):
+                value = [value]
+            out[slot.name] = value
             continue
 
         if range_class is None:
             # Scalar range.
-            if slot.multivalued:
-                if not isinstance(value, list):
-                    value = [value]
-                out[slot.name] = LIST_JOIN.join(_stringify(v) for v in value)
-            else:
-                out[slot.name] = value
+            if slot.multivalued and not isinstance(value, list):
+                value = [value]
+            out[slot.name] = value
             continue
 
         # Class range, inlined.
@@ -144,7 +133,7 @@ def _dispatch_class(record: dict, declared_class: str, schema_view: SchemaView) 
 def _expand_inlined(value: dict, class_def: ClassDefinition, schema_view: SchemaView) -> dict[str, Any]:
     """Flatten a single-valued inlined object one level deep.
 
-    Scalar subslots pass through; multivalued scalars pipe-join. Nested
+    Scalar subslots pass through; multivalued scalars become lists. Nested
     classes inside the inlined object are expanded one more level (so
     ``env_broad_scale.term.id`` becomes ``env_broad_scale_term_id``), then
     anything deeper is dropped. This matches the common NMDC shape where
@@ -164,12 +153,9 @@ def _expand_inlined(value: dict, class_def: ClassDefinition, schema_view: Schema
         sub_range = _range_class(sub_slot, schema_view)
         if sub_range is None:
             # Scalar.
-            if sub_slot.multivalued:
-                if not isinstance(sub_value, list):
-                    sub_value = [sub_value]
-                out[sub_slot.name] = LIST_JOIN.join(_stringify(v) for v in sub_value)
-            else:
-                out[sub_slot.name] = sub_value
+            if sub_slot.multivalued and not isinstance(sub_value, list):
+                sub_value = [sub_value]
+            out[sub_slot.name] = sub_value
             continue
         # One more level of nesting allowed: expand scalar subslots of this inner class.
         if not sub_slot.multivalued and isinstance(sub_value, dict):
@@ -184,20 +170,10 @@ def _expand_inlined(value: dict, class_def: ClassDefinition, schema_view: Schema
                 if _range_class(inner_slot, schema_view) is not None:
                     # Three levels deep — dropped.
                     continue
-                if inner_slot.multivalued:
-                    if not isinstance(inner_value, list):
-                        inner_value = [inner_value]
-                    out[f"{sub_slot.name}_{inner_slot.name}"] = LIST_JOIN.join(_stringify(v) for v in inner_value)
-                else:
-                    out[f"{sub_slot.name}_{inner_slot.name}"] = inner_value
+                if inner_slot.multivalued and not isinstance(inner_value, list):
+                    inner_value = [inner_value]
+                out[f"{sub_slot.name}_{inner_slot.name}"] = inner_value
     return out
-
-
-def _stringify(value: Any) -> str:
-    """Coerce a value to its string representation for pipe-joining."""
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    return str(value)
 
 
 def side_table_rows(
@@ -208,13 +184,15 @@ def side_table_rows(
 ) -> Iterator[tuple[str, dict]]:
     """Yield ``(table_name, row_dict)`` for every side table row from one record.
 
-    Three slot types produce side table rows:
+    Two slot types produce side table rows:
 
-    - **scalar multivalued** — one ``(parent_id, <slot_name>)`` row per element.
     - **ref_class multivalued** (class range, not inlined) — one
-      ``(parent_id, <slot_name>)`` row per referenced ID.
+      ``(parent_id, <slot_name>)`` junction row per referenced ID.
     - **inlined_class multivalued** — one flattened child-object row per element,
       with ``parent_id`` prepended.
+
+    Scalar multivalued slots are stored as native Parquet ARRAY columns in the
+    primary table and do NOT produce side table rows.
 
     ``table_name`` is ``{collection}_{slot_name}`` in all cases.
 
@@ -252,16 +230,19 @@ def side_table_rows(
         range_class = _range_class(slot, schema_view)
 
         if range_class is not None and _is_inlined(slot, schema_view):
+            # Inlined multivalued → child side table
             for child in value:
                 if not isinstance(child, dict):
                     continue
                 row = _expand_inlined(child, range_class, schema_view)
                 row["parent_id"] = parent_id
                 yield table_name, row
-        else:
+        elif range_class is not None:
+            # Ref-class multivalued → junction table (ARRAY also in primary)
             for v in value:
                 if v is not None:
                     yield table_name, {"parent_id": parent_id, slot.name: v}
+        # Scalar multivalued: ARRAY column in primary table, no side table row
 
 
 class SchemaDrivenFlattener:

--- a/src/nmdc_lakehouse/transforms/schema_generator.py
+++ b/src/nmdc_lakehouse/transforms/schema_generator.py
@@ -145,6 +145,62 @@ def flatten_database_schema(
     return out
 
 
+def side_table_class_defs(
+    schema_view: SchemaView,
+    root_class: str,
+    collection: str,
+) -> list[tuple[str, ClassDefinition]]:
+    """Return ``(table_name, ClassDefinition)`` pairs for all side tables of ``root_class``.
+
+    Mirrors the decision tree in :func:`nmdc_lakehouse.transforms.flatteners.side_table_rows`:
+
+    - **scalar** or **ref_class** multivalued: junction table with two slots,
+      ``parent_id`` (string) and ``<slot_name>`` (slot's range or string for refs).
+    - **inlined_class** multivalued: child-class flat schema (via
+      :func:`flatten_class_def`) plus a ``parent_id`` slot.
+
+    Scans ``root_class`` and all its proper descendants so polymorphic
+    subclass-specific slots (e.g. ``mags_list`` on ``MagsAnalysis``) are
+    included even when the collection is declared against the abstract base.
+
+    Args:
+        schema_view: Loaded LinkML SchemaView.
+        root_class: Root class for this collection.
+        collection: Collection name — used as the table name prefix.
+
+    Returns:
+        List of ``(table_name, ClassDefinition)`` pairs, one per distinct
+        multivalued slot. Ordered by table name for deterministic output.
+    """
+    result: list[tuple[str, ClassDefinition]] = []
+    seen: set[str] = set()
+
+    for class_name in [root_class] + _proper_descendants(schema_view, root_class):
+        for slot in schema_view.class_induced_slots(class_name):
+            if not slot.multivalued:
+                continue
+            table_name = f"{collection}_{slot.name}"
+            if table_name in seen:
+                continue
+            seen.add(table_name)
+
+            range_class = _range_class(slot, schema_view)
+
+            if range_class is not None and _is_inlined(slot, schema_view):
+                child_flat = flatten_class_def(schema_view, range_class.name, target_name=table_name)
+                child_flat.attributes["parent_id"] = SlotDefinition(name="parent_id", range="string")
+                result.append((table_name, child_flat))
+            else:
+                cls = ClassDefinition(name=table_name)
+                cls.attributes["parent_id"] = SlotDefinition(name="parent_id", range="string")
+                value_range = "string" if range_class is not None else (slot.range or "string")
+                cls.attributes[slot.name] = SlotDefinition(name=slot.name, range=value_range)
+                result.append((table_name, cls))
+
+    result.sort(key=lambda x: x[0])
+    return result
+
+
 def _flatten_slot(
     slot: SlotDefinition,
     schema_view: SchemaView,

--- a/src/nmdc_lakehouse/transforms/schema_generator.py
+++ b/src/nmdc_lakehouse/transforms/schema_generator.py
@@ -41,7 +41,6 @@ def _is_inlined(slot: SlotDefinition, schema_view: SchemaView) -> bool:
     return schema_view.get_identifier_slot(slot.range) is None
 
 
-LIST_JOIN_NOTE = "Multivalued slot flattened to a pipe-separated string (values joined with '|')."
 REF_NOTE = "Reference by identifier; original range was class '{range}'."
 NESTED_NOTE = "Flattened from nested slot '{parent}.{inner}'."
 DISPATCH_NOTE = "Polymorphic subclass-specific slot (from '{subclass}')."
@@ -53,11 +52,11 @@ def flatten_class_def(schema_view: SchemaView, root_class: str, target_name: str
     Walks the same decision tree as ``flatten_record``:
 
     - scalar → flat slot with same range
-    - multivalued scalar → flat slot with string range (pipe-joined)
-    - class range, not inlined → flat slot with string range (ID reference)
+    - multivalued scalar → flat slot with same range, multivalued=True (Parquet ARRAY)
+    - class range, not inlined → flat string slot (single) or multivalued string (ARRAY of IDs)
     - single-valued inlined class → one flat slot per subclass scalar slot,
       named ``<parent>_<inner>`` (one or two levels deep)
-    - multivalued inlined class → **skipped** (helper-table follow-up)
+    - multivalued inlined class → **skipped** (child side tables capture these)
 
     Union polymorphism: slots on concrete subclasses of ``root_class`` are
     unioned in, annotated with ``DISPATCH_NOTE`` so downstream consumers can
@@ -154,10 +153,13 @@ def side_table_class_defs(
 
     Mirrors the decision tree in :func:`nmdc_lakehouse.transforms.flatteners.side_table_rows`:
 
-    - **scalar** or **ref_class** multivalued: junction table with two slots,
-      ``parent_id`` (string) and ``<slot_name>`` (slot's range or string for refs).
+    - **ref_class** multivalued (class range, not inlined): junction table with two slots,
+      ``parent_id`` (string) and ``<slot_name>`` (string ID).
     - **inlined_class** multivalued: child-class flat schema (via
       :func:`flatten_class_def`) plus a ``parent_id`` slot.
+
+    Scalar multivalued slots are ARRAY columns in the primary table and have no
+    side table ClassDef.
 
     Scans ``root_class`` and all its proper descendants so polymorphic
     subclass-specific slots (e.g. ``mags_list`` on ``MagsAnalysis``) are
@@ -169,8 +171,7 @@ def side_table_class_defs(
         collection: Collection name — used as the table name prefix.
 
     Returns:
-        List of ``(table_name, ClassDefinition)`` pairs, one per distinct
-        multivalued slot. Ordered by table name for deterministic output.
+        List of ``(table_name, ClassDefinition)`` pairs. Ordered by table name.
     """
     result: list[tuple[str, ClassDefinition]] = []
     seen: set[str] = set()
@@ -187,15 +188,17 @@ def side_table_class_defs(
             range_class = _range_class(slot, schema_view)
 
             if range_class is not None and _is_inlined(slot, schema_view):
+                # Inlined multivalued → child side table
                 child_flat = flatten_class_def(schema_view, range_class.name, target_name=table_name)
                 child_flat.attributes["parent_id"] = SlotDefinition(name="parent_id", range="string")
                 result.append((table_name, child_flat))
-            else:
+            elif range_class is not None:
+                # Ref-class multivalued → junction table (ARRAY also in primary)
                 cls = ClassDefinition(name=table_name)
                 cls.attributes["parent_id"] = SlotDefinition(name="parent_id", range="string")
-                value_range = "string" if range_class is not None else (slot.range or "string")
-                cls.attributes[slot.name] = SlotDefinition(name=slot.name, range=value_range)
+                cls.attributes[slot.name] = SlotDefinition(name=slot.name, range="string")
                 result.append((table_name, cls))
+            # Scalar multivalued: ARRAY in primary table, no ClassDef
 
     result.sort(key=lambda x: x[0])
     return result
@@ -216,41 +219,31 @@ def _flatten_slot(
     if dispatch_subclass:
         notes.append(DISPATCH_NOTE.format(subclass=dispatch_subclass))
 
-    # Class range, not inlined → reference (string)
+    # Class range, not inlined → reference (string scalar or ARRAY of ID strings)
     if range_class is not None and not _is_inlined(slot, schema_view):
-        yield _flat_string_slot(
-            slot.name,
-            slot,
-            description=(slot.description or "")
-            + (" " if slot.description else "")
-            + REF_NOTE.format(range=slot.range)
-            + (" " + LIST_JOIN_NOTE if slot.multivalued else ""),
-            required_override=(slot.required if not dispatch_subclass else False),
-            notes=notes,
+        ref_desc = ((slot.description or "") + " " + REF_NOTE.format(range=slot.range)).strip()
+        new_slot = SlotDefinition(
+            name=slot.name,
+            range="string",
+            multivalued=slot.multivalued or False,
+            description=ref_desc or None,
+            required=(slot.required if not dispatch_subclass else False),
         )
+        _attach_notes(new_slot, notes)
+        yield new_slot
         return
 
-    # Scalar range
+    # Scalar range (scalar or ARRAY)
     if range_class is None:
-        description = slot.description or ""
-        if slot.multivalued:
-            description = (description + " " + LIST_JOIN_NOTE).strip()
-            yield _flat_string_slot(
-                slot.name,
-                slot,
-                description=description,
-                required_override=(slot.required if not dispatch_subclass else False),
-                notes=notes,
-            )
-        else:
-            new_slot = SlotDefinition(
-                name=slot.name,
-                range=slot.range,
-                description=description or None,
-                required=(slot.required if not dispatch_subclass else False),
-            )
-            _attach_notes(new_slot, notes)
-            yield new_slot
+        new_slot = SlotDefinition(
+            name=slot.name,
+            range=slot.range,
+            multivalued=slot.multivalued or False,
+            description=slot.description or None,
+            required=(slot.required if not dispatch_subclass else False),
+        )
+        _attach_notes(new_slot, notes)
+        yield new_slot
         return
 
     # Class range, inlined
@@ -267,32 +260,18 @@ def _flatten_slot(
         if inner_range is None:
             flat_name = f"{slot.name}_{inner_slot.name}"
             inner_description = inner_slot.description or ""
-            if inner_slot.multivalued:
-                description = (
-                    inner_description
-                    + " "
-                    + NESTED_NOTE.format(parent=slot.name, inner=inner_slot.name)
-                    + " "
-                    + LIST_JOIN_NOTE
-                ).strip()
-                yield _flat_string_slot(
-                    flat_name,
-                    inner_slot,
-                    description=description,
-                    required_override=False,
-                    notes=notes,
-                )
-            else:
-                new_slot = SlotDefinition(
-                    name=flat_name,
-                    range=inner_slot.range,
-                    description=(
-                        (inner_description + " " + NESTED_NOTE.format(parent=slot.name, inner=inner_slot.name)).strip()
-                    ),
-                    required=False,
-                )
-                _attach_notes(new_slot, notes)
-                yield new_slot
+            nested_desc = (
+                inner_description + " " + NESTED_NOTE.format(parent=slot.name, inner=inner_slot.name)
+            ).strip()
+            new_slot = SlotDefinition(
+                name=flat_name,
+                range=inner_slot.range,
+                multivalued=inner_slot.multivalued or False,
+                description=nested_desc or None,
+                required=False,
+            )
+            _attach_notes(new_slot, notes)
+            yield new_slot
             continue
         # One more level of nesting (term → id/name)
         if not inner_slot.multivalued:
@@ -303,42 +282,20 @@ def _flatten_slot(
                     continue  # Three levels deep is out of scope
                 flat_name = f"{slot.name}_{inner_slot.name}_{deepest.name}"
                 deep_description = deepest.description or ""
-                if deepest.multivalued:
-                    description = (
-                        deep_description
-                        + " "
-                        + NESTED_NOTE.format(
-                            parent=f"{slot.name}.{inner_slot.name}",
-                            inner=deepest.name,
-                        )
-                        + " "
-                        + LIST_JOIN_NOTE
-                    ).strip()
-                    yield _flat_string_slot(
-                        flat_name,
-                        deepest,
-                        description=description,
-                        required_override=False,
-                        notes=notes,
-                    )
-                else:
-                    new_slot = SlotDefinition(
-                        name=flat_name,
-                        range=deepest.range,
-                        description=(
-                            (
-                                deep_description
-                                + " "
-                                + NESTED_NOTE.format(
-                                    parent=f"{slot.name}.{inner_slot.name}",
-                                    inner=deepest.name,
-                                )
-                            ).strip()
-                        ),
-                        required=False,
-                    )
-                    _attach_notes(new_slot, notes)
-                    yield new_slot
+                nested_desc = (
+                    deep_description
+                    + " "
+                    + NESTED_NOTE.format(parent=f"{slot.name}.{inner_slot.name}", inner=deepest.name)
+                ).strip()
+                new_slot = SlotDefinition(
+                    name=flat_name,
+                    range=deepest.range,
+                    multivalued=deepest.multivalued or False,
+                    description=nested_desc or None,
+                    required=False,
+                )
+                _attach_notes(new_slot, notes)
+                yield new_slot
 
 
 def _range_class(slot: SlotDefinition, schema_view: SchemaView):
@@ -346,24 +303,6 @@ def _range_class(slot: SlotDefinition, schema_view: SchemaView):
     if not slot.range:
         return None
     return schema_view.get_class(slot.range)
-
-
-def _flat_string_slot(
-    name: str,
-    source: SlotDefinition,
-    description: str,
-    required_override: bool | None,
-    notes: list[str],
-) -> SlotDefinition:
-    """Construct a flat SlotDefinition with a string range."""
-    slot = SlotDefinition(
-        name=name,
-        range="string",
-        description=description or None,
-        required=required_override,
-    )
-    _attach_notes(slot, notes)
-    return slot
 
 
 def _attach_notes(slot: SlotDefinition, notes: list[str]) -> None:

--- a/tests/test_flatteners.py
+++ b/tests/test_flatteners.py
@@ -36,6 +36,8 @@ classes:
   ControlledTermValue:
     attributes:
       has_raw_value:
+      aliases:
+        multivalued: true
       term:
         range: Term
 
@@ -108,16 +110,16 @@ def test_scalar_passthrough(sv):
     assert out == {"id": "r1", "name": "first", "depth": 3.5}
 
 
-def test_multivalued_scalar_pipe_joined(sv):
-    """Multivalued scalar slots are joined with '|'."""
+def test_multivalued_scalar_is_array(sv):
+    """Multivalued scalar slots become a native list (Parquet ARRAY)."""
     out = flatten_record({"id": "r1", "tags": ["a", "b", "c"]}, sv, "Record")
-    assert out["tags"] == "a|b|c"
+    assert out["tags"] == ["a", "b", "c"]
 
 
-def test_single_valued_scalar_not_wrapped_in_list(sv):
-    """A non-list value for a multivalued slot still works (wrapped into one)."""
+def test_single_valued_scalar_wrapped_in_list(sv):
+    """A non-list value for a multivalued slot is wrapped into a single-element list."""
     out = flatten_record({"id": "r1", "tags": "lonely"}, sv, "Record")
-    assert out["tags"] == "lonely"
+    assert out["tags"] == ["lonely"]
 
 
 def test_inlined_object_expanded_one_level(sv):
@@ -129,6 +131,16 @@ def test_inlined_object_expanded_one_level(sv):
     )
     assert out["description_has_raw_value"] == "notes here"
     assert "description" not in out
+
+
+def test_inlined_object_multivalued_subslot_is_array(sv):
+    """Multivalued scalar subslot inside a single-valued inlined object becomes a list."""
+    out = flatten_record(
+        {"id": "r1", "env_broad_scale": {"has_raw_value": "x", "aliases": ["a", "b"]}},
+        sv,
+        "Record",
+    )
+    assert out["env_broad_scale_aliases"] == ["a", "b"]
 
 
 def test_inlined_object_expanded_two_levels(sv):
@@ -149,14 +161,14 @@ def test_inlined_object_expanded_two_levels(sv):
     assert out["env_broad_scale_term_name"] == "freshwater river biome"
 
 
-def test_multivalued_class_ref_pipe_joined(sv):
-    """Multivalued class-range slot without inlined=True treats values as ID refs."""
+def test_multivalued_class_ref_is_array(sv):
+    """Multivalued class-range slot without inlined=True becomes a list of IDs."""
     out = flatten_record(
         {"id": "r1", "associated_studies": ["nmdc:sty-11-a", "nmdc:sty-11-b"]},
         sv,
         "Record",
     )
-    assert out["associated_studies"] == "nmdc:sty-11-a|nmdc:sty-11-b"
+    assert out["associated_studies"] == ["nmdc:sty-11-a", "nmdc:sty-11-b"]
 
 
 def test_single_class_ref_passthrough(sv):
@@ -206,12 +218,10 @@ def test_flattener_apply_yields_one_per_record(sv):
     assert out == [{"id": "r1", "name": "first"}, {"id": "r2", "name": "second"}]
 
 
-def test_boolean_scalars_stringified_in_list(sv):
-    """Booleans inside multivalued scalar lists are rendered as 'true'/'false'."""
-    # Not directly supported by the test schema, but _stringify is called for
-    # multivalued scalars — add a minimal case using tags.
+def test_boolean_scalars_preserved_in_array(sv):
+    """Booleans inside multivalued scalar lists are preserved as booleans."""
     out = flatten_record({"id": "r1", "tags": [True, False]}, sv, "Record")
-    assert out["tags"] == "true|false"
+    assert out["tags"] == [True, False]
 
 
 def test_polymorphic_dispatch_root_class(sv):
@@ -277,13 +287,10 @@ def test_polymorphic_dispatch_in_inlined_object(sv):
 # ── side_table_rows ────────────────────────────────────────────────────────────
 
 
-def test_side_table_scalar_multivalued(sv):
-    """Scalar multivalued slots produce one junction row per element."""
+def test_side_table_scalar_multivalued_no_rows(sv):
+    """Scalar multivalued slots produce no side table rows (ARRAY in primary table)."""
     rows = list(side_table_rows({"id": "r1", "tags": ["a", "b"]}, sv, "Record", "record_set"))
-    assert rows == [
-        ("record_set_tags", {"parent_id": "r1", "tags": "a"}),
-        ("record_set_tags", {"parent_id": "r1", "tags": "b"}),
-    ]
+    assert rows == []
 
 
 def test_side_table_ref_class_multivalued(sv):
@@ -343,14 +350,10 @@ def test_side_table_empty_list_skipped(sv):
     assert rows == []
 
 
-def test_side_table_preserves_non_string_types(sv):
-    """Integer values in side table rows are not cast to string."""
+def test_side_table_scalar_integer_no_rows(sv):
+    """Scalar integer multivalued slots produce no side table rows (ARRAY in primary table)."""
     rows = list(side_table_rows({"id": "r1", "scores": [1, 2, 3]}, sv, "Record", "record_set"))
-    assert rows == [
-        ("record_set_scores", {"parent_id": "r1", "scores": 1}),
-        ("record_set_scores", {"parent_id": "r1", "scores": 2}),
-        ("record_set_scores", {"parent_id": "r1", "scores": 3}),
-    ]
+    assert rows == []
 
 
 def test_side_table_dispatch_outside_hierarchy_falls_back(sv):

--- a/tests/test_flatteners.py
+++ b/tests/test_flatteners.py
@@ -64,6 +64,9 @@ classes:
       associated_studies:
         range: Term
         multivalued: true
+      scores:
+        range: integer
+        multivalued: true
       parent:
         range: Term
       type:
@@ -338,3 +341,30 @@ def test_side_table_empty_list_skipped(sv):
     """Empty list values produce no rows."""
     rows = list(side_table_rows({"id": "r1", "tags": []}, sv, "Record", "record_set"))
     assert rows == []
+
+
+def test_side_table_preserves_non_string_types(sv):
+    """Integer values in side table rows are not cast to string."""
+    rows = list(side_table_rows({"id": "r1", "scores": [1, 2, 3]}, sv, "Record", "record_set"))
+    assert rows == [
+        ("record_set_scores", {"parent_id": "r1", "scores": 1}),
+        ("record_set_scores", {"parent_id": "r1", "scores": 2}),
+        ("record_set_scores", {"parent_id": "r1", "scores": 3}),
+    ]
+
+
+def test_side_table_dispatch_outside_hierarchy_falls_back(sv):
+    """A record whose type is outside the root_class hierarchy falls back to root_class slots."""
+    # Process is not a descendant of Record — Extraction has extraction_targets (multivalued).
+    # Without the hierarchy guard, side_table_rows would iterate Extraction slots and emit
+    # record_set_extraction_targets rows that have no ClassDef in side_table_class_defs.
+    rows = list(
+        side_table_rows(
+            {"id": "r1", "type": "test:Extraction", "extraction_targets": ["x"]},
+            sv,
+            "Record",
+            "record_set",
+        )
+    )
+    table_names = {t for t, _ in rows}
+    assert "record_set_extraction_targets" not in table_names

--- a/tests/test_flatteners.py
+++ b/tests/test_flatteners.py
@@ -13,6 +13,7 @@ from linkml_runtime import SchemaView
 from nmdc_lakehouse.transforms.flatteners import (
     SchemaDrivenFlattener,
     flatten_record,
+    side_table_rows,
 )
 
 _SCHEMA_YAML = """
@@ -268,3 +269,72 @@ def test_polymorphic_dispatch_in_inlined_object(sv):
     # the inlined expansion, producing performed_step_pooling_method.
     assert out["performed_step_id"] == "step-1"
     assert out["performed_step_pooling_method"] == "serial"
+
+
+# ── side_table_rows ────────────────────────────────────────────────────────────
+
+
+def test_side_table_scalar_multivalued(sv):
+    """Scalar multivalued slots produce one junction row per element."""
+    rows = list(side_table_rows({"id": "r1", "tags": ["a", "b"]}, sv, "Record", "record_set"))
+    assert rows == [
+        ("record_set_tags", {"parent_id": "r1", "tags": "a"}),
+        ("record_set_tags", {"parent_id": "r1", "tags": "b"}),
+    ]
+
+
+def test_side_table_ref_class_multivalued(sv):
+    """Ref-class multivalued slots produce one junction row per referenced ID."""
+    rows = list(
+        side_table_rows(
+            {"id": "r1", "associated_studies": ["nmdc:sty-11-a", "nmdc:sty-11-b"]},
+            sv,
+            "Record",
+            "record_set",
+        )
+    )
+    assert rows == [
+        ("record_set_associated_studies", {"parent_id": "r1", "associated_studies": "nmdc:sty-11-a"}),
+        ("record_set_associated_studies", {"parent_id": "r1", "associated_studies": "nmdc:sty-11-b"}),
+    ]
+
+
+def test_side_table_inlined_class_multivalued(sv):
+    """Inlined-class multivalued slots produce one flattened child row per element."""
+    rows = list(
+        side_table_rows(
+            {
+                "id": "r1",
+                "chem_admin": [
+                    {"has_raw_value": "formaldehyde"},
+                    {"has_raw_value": "methanol"},
+                ],
+            },
+            sv,
+            "Record",
+            "record_set",
+        )
+    )
+    tables = [t for t, _ in rows]
+    assert all(t == "record_set_chem_admin" for t in tables)
+    child_rows = [r for _, r in rows]
+    assert child_rows[0] == {"has_raw_value": "formaldehyde", "parent_id": "r1"}
+    assert child_rows[1] == {"has_raw_value": "methanol", "parent_id": "r1"}
+
+
+def test_side_table_no_multivalued_slots(sv):
+    """Records with no multivalued slots emit no side table rows."""
+    rows = list(side_table_rows({"id": "r1", "name": "x"}, sv, "Record", "record_set"))
+    assert rows == []
+
+
+def test_side_table_missing_slot_skipped(sv):
+    """Slots absent from the record are silently skipped."""
+    rows = list(side_table_rows({"id": "r1"}, sv, "Record", "record_set"))
+    assert rows == []
+
+
+def test_side_table_empty_list_skipped(sv):
+    """Empty list values produce no rows."""
+    rows = list(side_table_rows({"id": "r1", "tags": []}, sv, "Record", "record_set"))
+    assert rows == []

--- a/tests/test_parquet_sink.py
+++ b/tests/test_parquet_sink.py
@@ -186,3 +186,15 @@ def test_drop_empty_cols_removes_all_null_columns(flat_class, tmp_path):
     assert "depth_has_numeric_value" not in tbl.schema.names
     assert "count" not in tbl.schema.names
     assert "active" not in tbl.schema.names
+
+
+def test_drop_empty_cols_removes_all_empty_array_columns(array_class, tmp_path):
+    """drop_empty_cols=True strips ARRAY columns where every row has [] or null."""
+    sink = ParquetSink(tmp_path, class_def=array_class)
+    rows = [{"id": "r1", "tags": ["a"]}, {"id": "r2"}]
+    sink.write(iter(rows), table="array_record", drop_empty_cols=True)
+    tbl = pq.read_table(tmp_path / "array_record.parquet")
+    assert "id" in tbl.schema.names
+    assert "tags" in tbl.schema.names  # has data
+    assert "scores" not in tbl.schema.names  # all null/empty
+    assert "associated_studies" not in tbl.schema.names  # all null/empty

--- a/tests/test_parquet_sink.py
+++ b/tests/test_parquet_sink.py
@@ -39,6 +39,35 @@ classes:
     return sv.get_class("FlatRecord")
 
 
+@pytest.fixture
+def array_class() -> ClassDefinition:
+    """A ClassDefinition with multivalued (ARRAY) slots of various element types."""
+    sv = SchemaView("""
+id: https://example.org/test
+name: test
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  ArrayRecord:
+    attributes:
+      id:
+        range: string
+        required: true
+      tags:
+        range: string
+        multivalued: true
+      scores:
+        range: integer
+        multivalued: true
+      associated_studies:
+        range: string
+        multivalued: true
+""")
+    return sv.get_class("ArrayRecord")
+
+
 def test_arrow_schema_types(flat_class, tmp_path):
     """class_def_to_arrow_schema maps ranges to Arrow types correctly."""
     schema = class_def_to_arrow_schema(flat_class)
@@ -116,6 +145,33 @@ def test_write_empty_input(flat_class, tmp_path):
     total = sink.write(iter([]), table="flat_record")
     assert total == 0
     assert not (tmp_path / "flat_record.parquet").exists()
+
+
+def test_arrow_schema_multivalued_becomes_list_type(array_class):
+    """Multivalued slots map to pa.list_(element_type) in the Arrow schema."""
+    schema = class_def_to_arrow_schema(array_class)
+    field_map = {f.name: f.type for f in schema}
+    assert field_map["tags"] == pa.list_(pa.string())
+    assert field_map["scores"] == pa.list_(pa.int64())
+    assert field_map["associated_studies"] == pa.list_(pa.string())
+    assert field_map["id"] == pa.string()  # single-valued — not a list
+
+
+def test_write_array_columns_roundtrip(array_class, tmp_path):
+    """ARRAY columns survive a write/read roundtrip with correct values."""
+    sink = ParquetSink(tmp_path, class_def=array_class)
+    rows = [
+        {"id": "r1", "tags": ["a", "b"], "scores": [1, 2, 3]},
+        {"id": "r2", "tags": ["x"]},
+        {"id": "r3"},  # all array cols null
+    ]
+    total = sink.write(iter(rows), table="array_record")
+    assert total == 3
+    tbl = pq.read_table(tmp_path / "array_record.parquet")
+    assert tbl.schema.field("tags").type == pa.list_(pa.string())
+    assert tbl.schema.field("scores").type == pa.list_(pa.int64())
+    assert tbl.column("tags").to_pylist() == [["a", "b"], ["x"], None]
+    assert tbl.column("scores").to_pylist() == [[1, 2, 3], None, None]
 
 
 def test_drop_empty_cols_removes_all_null_columns(flat_class, tmp_path):

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -78,6 +78,9 @@ classes:
       associated_studies:
         range: Term
         multivalued: true
+      scores:
+        range: integer
+        multivalued: true
       parent:
         range: Term
 
@@ -215,3 +218,11 @@ def test_side_table_output_sorted(sv):
     defs = side_table_class_defs(sv, "Record", "record_set")
     names = [t for t, _ in defs]
     assert names == sorted(names)
+
+
+def test_side_table_scalar_preserves_declared_range(sv):
+    """Non-string scalar multivalued slots retain their declared range in the ClassDef."""
+    defs = dict(side_table_class_defs(sv, "Record", "record_set"))
+    assert "record_set_scores" in defs
+    cls = defs["record_set_scores"]
+    assert cls.attributes["scores"].range == "integer"

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -109,12 +109,13 @@ def test_flat_class_includes_scalar_slots(sv):
     assert "name" in flat.attributes
 
 
-def test_flat_class_pipe_joins_multivalued_scalar(sv):
-    """Multivalued scalar slots become a single string slot, with note."""
+def test_flat_class_multivalued_scalar_is_array(sv):
+    """Multivalued scalar slots have multivalued=True and retain their declared range."""
     flat = flatten_class_def(sv, "Record")
     tags = flat.attributes["tags"]
-    assert tags.range == "string"
-    assert "pipe-separated" in (tags.description or "")
+    assert tags.multivalued is True
+    assert tags.range == "string"  # default_range in test schema
+    assert "pipe-separated" not in (tags.description or "")
 
 
 def test_flat_class_treats_class_ref_as_scalar(sv):
@@ -122,7 +123,16 @@ def test_flat_class_treats_class_ref_as_scalar(sv):
     flat = flatten_class_def(sv, "Record")
     parent = flat.attributes["parent"]
     assert parent.range == "string"
+    assert parent.multivalued is False
     assert "Reference by identifier" in (parent.description or "")
+
+
+def test_flat_class_multivalued_ref_is_array_of_strings(sv):
+    """Multivalued ref-class slot becomes multivalued=True with string range."""
+    flat = flatten_class_def(sv, "Record")
+    assoc = flat.attributes["associated_studies"]
+    assert assoc.range == "string"
+    assert assoc.multivalued is True
 
 
 def test_flat_class_expands_inlined_object(sv):
@@ -167,14 +177,10 @@ def test_flatten_database_schema_yields_one_class_per_collection(sv):
 # ── side_table_class_defs ─────────────────────────────────────────────────────
 
 
-def test_side_table_scalar_junction(sv):
-    """Scalar multivalued slot produces a two-column junction ClassDef."""
+def test_side_table_scalar_no_classdef(sv):
+    """Scalar multivalued slots produce no side table ClassDef (ARRAY in primary)."""
     defs = dict(side_table_class_defs(sv, "Record", "record_set"))
-    assert "record_set_tags" in defs
-    cls = defs["record_set_tags"]
-    assert "parent_id" in cls.attributes
-    assert "tags" in cls.attributes
-    assert cls.attributes["parent_id"].range == "string"
+    assert "record_set_tags" not in defs
 
 
 def test_side_table_ref_class_junction(sv):
@@ -206,11 +212,11 @@ def test_side_table_single_valued_slots_excluded(sv):
     assert "record_set_parent" not in defs
 
 
-def test_side_table_includes_descendant_slots(sv):
-    """Subclass-specific multivalued slots appear via proper-descendants scan."""
+def test_side_table_excludes_descendant_scalar_slots(sv):
+    """Subclass-specific scalar multivalued slots have no side table (ARRAY in primary)."""
     defs = dict(side_table_class_defs(sv, "Process", "process_set"))
-    # extraction_targets is only on Extraction, a subclass of Process
-    assert "process_set_extraction_targets" in defs
+    # extraction_targets is scalar multivalued on Extraction — no side table
+    assert "process_set_extraction_targets" not in defs
 
 
 def test_side_table_output_sorted(sv):
@@ -220,9 +226,7 @@ def test_side_table_output_sorted(sv):
     assert names == sorted(names)
 
 
-def test_side_table_scalar_preserves_declared_range(sv):
-    """Non-string scalar multivalued slots retain their declared range in the ClassDef."""
+def test_side_table_scalar_integer_no_classdef(sv):
+    """Integer scalar multivalued slots produce no side table ClassDef (ARRAY in primary)."""
     defs = dict(side_table_class_defs(sv, "Record", "record_set"))
-    assert "record_set_scores" in defs
-    cls = defs["record_set_scores"]
-    assert cls.attributes["scores"].range == "integer"
+    assert "record_set_scores" not in defs

--- a/tests/test_schema_generator.py
+++ b/tests/test_schema_generator.py
@@ -12,6 +12,7 @@ from linkml_runtime import SchemaView
 from nmdc_lakehouse.transforms.schema_generator import (
     flatten_class_def,
     flatten_database_schema,
+    side_table_class_defs,
 )
 
 _SCHEMA_YAML = """
@@ -69,6 +70,10 @@ classes:
         inlined: true
       description:
         range: TextValue
+        inlined: true
+      chem_admin:
+        range: ControlledTermValue
+        multivalued: true
         inlined: true
       associated_studies:
         range: Term
@@ -154,3 +159,59 @@ def test_flatten_database_schema_yields_one_class_per_collection(sv):
 # emits exists in the generated class") will be added in a follow-up once
 # both #6 (flattener) and #12 (this) have landed and both helpers are in
 # the same source tree.
+
+
+# ── side_table_class_defs ─────────────────────────────────────────────────────
+
+
+def test_side_table_scalar_junction(sv):
+    """Scalar multivalued slot produces a two-column junction ClassDef."""
+    defs = dict(side_table_class_defs(sv, "Record", "record_set"))
+    assert "record_set_tags" in defs
+    cls = defs["record_set_tags"]
+    assert "parent_id" in cls.attributes
+    assert "tags" in cls.attributes
+    assert cls.attributes["parent_id"].range == "string"
+
+
+def test_side_table_ref_class_junction(sv):
+    """Ref-class multivalued slot produces a two-column junction ClassDef."""
+    defs = dict(side_table_class_defs(sv, "Record", "record_set"))
+    assert "record_set_associated_studies" in defs
+    cls = defs["record_set_associated_studies"]
+    assert "parent_id" in cls.attributes
+    assert "associated_studies" in cls.attributes
+    # ref type: value column is string (ID)
+    assert cls.attributes["associated_studies"].range == "string"
+
+
+def test_side_table_inlined_class_child(sv):
+    """Inlined-class multivalued slot produces child-object ClassDef with parent_id."""
+    defs = dict(side_table_class_defs(sv, "Record", "record_set"))
+    assert "record_set_chem_admin" in defs
+    cls = defs["record_set_chem_admin"]
+    assert "parent_id" in cls.attributes
+    # ControlledTermValue slots appear in the child schema
+    assert "has_raw_value" in cls.attributes
+
+
+def test_side_table_single_valued_slots_excluded(sv):
+    """Single-valued slots do not produce side tables."""
+    defs = dict(side_table_class_defs(sv, "Record", "record_set"))
+    assert "record_set_name" not in defs
+    assert "record_set_depth" not in defs
+    assert "record_set_parent" not in defs
+
+
+def test_side_table_includes_descendant_slots(sv):
+    """Subclass-specific multivalued slots appear via proper-descendants scan."""
+    defs = dict(side_table_class_defs(sv, "Process", "process_set"))
+    # extraction_targets is only on Extraction, a subclass of Process
+    assert "process_set_extraction_targets" in defs
+
+
+def test_side_table_output_sorted(sv):
+    """Output is sorted by table name for deterministic ordering."""
+    defs = side_table_class_defs(sv, "Record", "record_set")
+    names = [t for t, _ in defs]
+    assert names == sorted(names)


### PR DESCRIPTION
## What this does

Replaces pipe-joined string columns for multivalued slots with native Parquet ARRAY columns and proper side tables.

**Multivalued slot handling (new design):**
- Scalar multivalued (\`analysis_type\`, \`alternative_identifiers\`, etc.) → \`VARCHAR[]\` ARRAY in primary table. No junction side table.
- Ref-class multivalued (\`associated_studies\`, \`has_input\`, etc.) → \`VARCHAR[]\` ARRAY in primary table + junction side table for SQL JOINs.
- Inlined multivalued (\`chem_administration\`, \`mags_list\`, etc.) → child side table only (unchanged).

**Result on real data:** 46 output files vs 79 with the old design. 34 side tables instead of 68 — the eliminated 34 were scalar junction tables made redundant by ARRAY columns.

## Key changes

- \`flatteners.py\`: \`flatten_record\` and \`_expand_inlined\` return lists for multivalued slots instead of pipe-joined strings. \`side_table_rows\` no longer emits junction rows for scalar slots. Dead \`_stringify\` helper removed.
- \`schema_generator.py\`: \`flatten_class_def\` emits \`multivalued=True\` slots. \`side_table_class_defs\` no longer generates ClassDefs for scalar junction tables. Dead \`_flat_string_slot\` removed.
- \`parquet_sink.py\`: \`class_def_to_arrow_schema\` maps \`multivalued=True\` → \`pa.list_(element_type)\`. \`_coerce\` handles list columns recursively.

## Related

Closes #31. Known gaps filed: #61 (\`drop_empty_cols\` / empty-list edge case), #62 (silent drop of class-range MV inside inlined children).

**Note:** PR #65 stacks on top of this branch and should be merged after this one.