### PR TITLE
Add IdentitiesOnly=yes to tunnel recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,6 +66,7 @@ nmdc_jump_key := env_var_or_default("NMDC_JUMP_KEY", "~/.ssh/jump-dev.microbiome
 # Override the key path with NMDC_JUMP_KEY if needed.
 tunnel:
     ssh -i {{nmdc_jump_key}} \
+        -o IdentitiesOnly=yes \
         -L 27124:runtime-api-mongodb-headless.nmdc-prod.svc.cluster.local:27017 \
         -o ServerAliveInterval=60 \
         ssh-mongo@jump-dev.microbiomedata.org


### PR DESCRIPTION
Fixes the `tunnel` recipe failing with "Too many authentication failures" when the ssh-agent has multiple keys loaded.

`-o IdentitiesOnly=yes` forces SSH to use only the key passed via `-i` and skip any other keys offered by the agent.

Closes #59