### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           python-version: "3.11"
 
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Install dependencies
         run: uv sync --extra dev


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```